### PR TITLE
feat: adding an icons library component

### DIFF
--- a/src/components/icons-lib/icons/index.js
+++ b/src/components/icons-lib/icons/index.js
@@ -1,0 +1,21 @@
+import React from 'react';
+
+const icons = {
+  handle: (
+    <>
+      <circle cx="5" cy="3.5" r="1.5" />
+      <circle cx="11" cy="3.5" r="1.5" />
+      <circle cx="5" cy="8.5" r="1.5" />
+      <circle cx="11" cy="8.5" r="1.5" />
+      <circle cx="5" cy="13.5" r="1.5" />
+      <circle cx="11" cy="13.5" r="1.5" />
+    </>
+  ),
+};
+
+const TYPES = Object.keys(icons).reduce(
+  (acc, icon) => ({ ...acc, [icon.toUpperCase()]: icon }),
+  {}
+);
+
+export { icons, TYPES };

--- a/src/components/icons-lib/index.js
+++ b/src/components/icons-lib/index.js
@@ -1,0 +1,35 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import { icons, TYPES } from './icons';
+
+const IconsLib = ({ type, style = {}, className = '' }) => {
+  return (
+    <span className="icons-lib-wrapper">
+      <svg
+        className={`icons-lib ${className}`}
+        width="16"
+        height="16"
+        viewBox="0 0 16 16"
+        fill="none"
+        xmlns="http://www.w3.org/2000/svg"
+        focusable="false"
+        role="img"
+        style={style}
+      >
+        <title>{`${type} icon`}</title>
+        {icons[type]}
+      </svg>
+    </span>
+  );
+};
+
+IconsLib.TYPES = TYPES;
+
+IconsLib.propTypes = {
+  type: PropTypes.oneOf(Object.keys(TYPES)),
+  style: PropTypes.object,
+  className: PropTypes.string,
+};
+
+export default IconsLib;

--- a/src/components/icons-lib/styles.scss
+++ b/src/components/icons-lib/styles.scss
@@ -1,0 +1,13 @@
+.icons-lib-wrapper {
+  display: inline-block;
+  width: 1em;
+  height: 1em;
+  line-height: 1;
+  font-size: 16px;
+  vertical-align: middle;
+  color: #293338;
+
+  .icons-lib {
+    fill: currentColor;
+  }
+}


### PR DESCRIPTION
Adding an `IconsLib` component. Example...
```js
import { IconsLib } from '../../src/components';

<IconsLib type={IconsLib.TYPES.HANDLE} />
```