### PR TITLE
fix: warning status for service levels; add type to signal

### DIFF
--- a/src/components/signal/index.js
+++ b/src/components/signal/index.js
@@ -2,12 +2,12 @@ import React, { useMemo } from 'react';
 import PropTypes from 'prop-types';
 
 import { StatusIcon } from '@newrelic/nr-labs-components';
-import { signalStatus } from '../../utils';
+import { SIGNAL_TYPES, signalStatus } from '../../utils';
 
-const Signal = ({ name, attainment, target }) => {
+const Signal = ({ type = '', name, ...params }) => {
   const status = useMemo(
-    () => signalStatus({ attainment, target }),
-    [attainment, target]
+    () => signalStatus({ type, ...params }),
+    [type, params]
   );
 
   return (
@@ -19,9 +19,10 @@ const Signal = ({ name, attainment, target }) => {
 };
 
 Signal.propTypes = {
+  type: PropTypes.oneOf(Object.values(SIGNAL_TYPES)),
   name: PropTypes.string,
-  attainment: PropTypes.number,
-  target: PropTypes.number,
+  attainment: PropTypes.number, // for type === service_level
+  target: PropTypes.number, // for type === service_level
 };
 
 export default Signal;

--- a/src/components/signals-list/index.js
+++ b/src/components/signals-list/index.js
@@ -6,8 +6,8 @@ import Signal from '../signal';
 const SignalsList = ({ signals = [] }) => {
   return (
     <div className="signals-list">
-      {signals.map(({ name, attainment, target }, i) => (
-        <Signal key={i} name={name} attainment={attainment} target={target} />
+      {signals.map((signal, i) => (
+        <Signal key={i} {...signal} />
       ))}
     </div>
   );
@@ -16,9 +16,10 @@ const SignalsList = ({ signals = [] }) => {
 SignalsList.propTypes = {
   signals: PropTypes.arrayOf(
     PropTypes.shape({
+      type: PropTypes.string,
       name: PropTypes.string,
-      attainment: PropTypes.number,
-      target: PropTypes.number,
+      attainment: PropTypes.number, // for type === service_level
+      target: PropTypes.number, // for type === service_level
     })
   ),
 };

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,2 +1,3 @@
 export * from './regex';
 export * from './signal';
+export * from './service-levels';

--- a/src/utils/service-levels.js
+++ b/src/utils/service-levels.js
@@ -1,0 +1,35 @@
+import { StatusIcon } from '@newrelic/nr-labs-components';
+
+const {
+  STATUSES: { UNKNOWN, CRITICAL, WARNING, SUCCESS },
+} = StatusIcon;
+
+const maxDecimalDigits = (target) => {
+  const decimal = target.toString().split('.')[1];
+
+  if (!decimal) return 2;
+  if (decimal.length >= 6) return 6;
+  return decimal.length + 1;
+};
+
+export const serviceLevelStatus = ({ attainment, target }) => {
+  if (
+    attainment == null ||
+    typeof attainment !== 'number' ||
+    target == null ||
+    typeof target !== 'number'
+  )
+    return UNKNOWN;
+
+  const attainmentRounded = attainment.toFixed(maxDecimalDigits(target));
+
+  if (attainmentRounded < target) return CRITICAL;
+
+  const remainingErrorBudget =
+    target === 100
+      ? 0
+      : (Math.max(attainment - target, 0) / (100 - target)) * 100;
+  if (remainingErrorBudget < 25) return WARNING;
+
+  return SUCCESS;
+};

--- a/src/utils/signal.js
+++ b/src/utils/signal.js
@@ -1,18 +1,24 @@
 import { StatusIcon } from '@newrelic/nr-labs-components';
 
+import { serviceLevelStatus } from './service-levels';
+
 const {
-  STATUSES: { UNKNOWN, CRITICAL, SUCCESS },
+  STATUSES: { UNKNOWN },
 } = StatusIcon;
 
-const signalStatus = (signal) => {
-  if (!signal) return UNKNOWN;
-
-  const { attainment, target } = signal;
-
-  if ((!attainment && attainment !== 0) || !target) return UNKNOWN;
-
-  if (attainment >= target) return SUCCESS;
-  return CRITICAL;
+export const SIGNAL_TYPES = {
+  SERVICE_LEVEL: 'service_level',
 };
 
-export { signalStatus };
+export const signalStatus = (signal) => {
+  if (!signal) return UNKNOWN;
+
+  const { type = '' } = signal;
+
+  if (type === SIGNAL_TYPES.SERVICE_LEVEL) {
+    const { attainment, target } = signal;
+    return serviceLevelStatus({ attainment, target });
+  }
+
+  return UNKNOWN;
+};


### PR DESCRIPTION
- moved service level status into its own file
- added a warning status for service levels
- signal util now checks for type of signal before delegating to respective utils (only service levels for now) to fetch status
- updated `SignalList` and `Signal` components to accept `type` prop