### PR TITLE
fix: flows UI when inserting/removing flows from list

### DIFF
--- a/nerdlets/home/index.js
+++ b/nerdlets/home/index.js
@@ -143,7 +143,7 @@ const HomeNerdlet = () => {
   }, [createFlowError]);
 
   const currentView = useMemo(() => {
-    if (currentFlowIndex > -1)
+    if (currentFlowIndex > -1 && flows?.[currentFlowIndex]?.document) {
       return (
         <Flow
           flow={flows[currentFlowIndex].document}
@@ -155,6 +155,7 @@ const HomeNerdlet = () => {
           onSelectFlow={flowClickHandler}
         />
       );
+    }
     if (flows && flows.length)
       return <FlowList flows={flows} onClick={flowClickHandler} />;
     if (flowsLoading) {

--- a/src/components/delete-confirm-modal/index.js
+++ b/src/components/delete-confirm-modal/index.js
@@ -9,6 +9,7 @@ const DeleteConfirmModal = ({
   hidden = true,
   onConfirm,
   onClose,
+  isDeletingFlow,
 }) => {
   const deleteHandler = useCallback(() => {
     if (onConfirm) onConfirm();
@@ -35,10 +36,18 @@ const DeleteConfirmModal = ({
           ) : null}
         </div>
         <div className="modal-footer">
-          <Button type={Button.TYPE.DESTRUCTIVE} onClick={deleteHandler}>
+          <Button
+            loading={isDeletingFlow}
+            type={Button.TYPE.DESTRUCTIVE}
+            onClick={deleteHandler}
+          >
             Delete
           </Button>
-          <Button type={Button.TYPE.TERTIARY} onClick={closeHandler}>
+          <Button
+            disabled={isDeletingFlow}
+            type={Button.TYPE.TERTIARY}
+            onClick={closeHandler}
+          >
             Cancel
           </Button>
         </div>
@@ -53,6 +62,7 @@ DeleteConfirmModal.propTypes = {
   hidden: PropTypes.bool,
   onConfirm: PropTypes.func,
   onClose: PropTypes.func,
+  isDeletingFlow: PropTypes.bool,
 };
 
 export default DeleteConfirmModal;

--- a/src/components/flow/index.js
+++ b/src/components/flow/index.js
@@ -1,7 +1,7 @@
 import React, { useCallback, useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 
-import { useAccountStorageMutation } from 'nr1';
+import { Spinner, useAccountStorageMutation } from 'nr1';
 
 import { KpiBar, Stages, DeleteConfirmModal } from '../';
 import FlowHeader from './header';
@@ -16,6 +16,7 @@ const Flow = ({
   flows = [],
   onSelectFlow = () => null,
 }) => {
+  const [isDeletingFlow, setDeletingFlow] = useState(false);
   const [stages, setStages] = useState([]);
   const [kpis, setKpis] = useState([]);
   const [deleteModalHidden, setDeleteModalHidden] = useState(true);
@@ -63,13 +64,13 @@ const Flow = ({
       accountId: accountId,
     });
 
-  const deleteFlowHandler = useCallback(
-    () =>
-      deleteFlow({
-        documentId: flow.id,
-      }),
-    [flow]
-  );
+  const deleteFlowHandler = useCallback(async () => {
+    setDeletingFlow(true);
+    await deleteFlow({
+      documentId: flow.id,
+    });
+    setDeletingFlow(false);
+  }, [flow]);
 
   useEffect(() => {
     const { nerdStorageDeleteDocument: { deleted } = {} } =
@@ -83,18 +84,6 @@ const Flow = ({
 
   return (
     <div className="flow">
-      <FlowHeader
-        name={flow.name}
-        imageUrl={flow.imageUrl}
-        onUpdate={flowUpdateHandler}
-        onClose={onClose}
-        mode={mode}
-        flows={flows}
-        onSelectFlow={onSelectFlow}
-        onDeleteFlow={() => setDeleteModalHidden(false)}
-      />
-      <Stages stages={stages} onUpdate={flowUpdateHandler} mode={mode} />
-      <KpiBar kpis={kpis} onChange={updateKpisHandler} mode={mode} />
       {mode === MODES.EDIT && (
         <DeleteConfirmModal
           name={flow.name}
@@ -102,7 +91,26 @@ const Flow = ({
           hidden={deleteModalHidden}
           onConfirm={() => deleteFlowHandler()}
           onClose={() => setDeleteModalHidden(true)}
+          isDeletingFlow={isDeletingFlow}
         />
+      )}
+      {!isDeletingFlow ? (
+        <>
+          <FlowHeader
+            name={flow.name}
+            imageUrl={flow.imageUrl}
+            onUpdate={flowUpdateHandler}
+            onClose={onClose}
+            mode={mode}
+            flows={flows}
+            onSelectFlow={onSelectFlow}
+            onDeleteFlow={() => setDeleteModalHidden(false)}
+          />
+          <Stages stages={stages} onUpdate={flowUpdateHandler} mode={mode} />
+          <KpiBar kpis={kpis} onChange={updateKpisHandler} mode={mode} />
+        </>
+      ) : (
+        <Spinner />
       )}
     </div>
   );


### PR DESCRIPTION
- removing a flow from the flow list caused the next flow in the list to be displayed for a fraction of second. issue was fixed by using async/await to wait for the `delete` action to be completed, and then rendering the flow list.

- similarly when the last element of the flows list was removed, it caused a crash because the element was not in the array anymore, and caused an array out of bound error. setting a condition to ensure the current index is valid before displaying the flow fixed this issue.