### PR TITLE
fix: error in signal selection nerdlet

### DIFF
--- a/nerdlets/signal-selection/index.js
+++ b/nerdlets/signal-selection/index.js
@@ -94,8 +94,11 @@ const SignalSelectionNerdlet = () => {
     const step = steps.find(({ id }) => id === stepId) || {};
     const [existingEntities, existingAlerts] = (step?.signals || []).reduce(
       (acc, signal) => {
-        if (signal.type === SIGNAL_TYPES.ENTITY) acc[0].push(signal);
-        if (signal.type === SIGNAL_TYPES.ALERT) acc[1].push(signal);
+        if (signal?.type === SIGNAL_TYPES.ENTITY) {
+          acc[0].push(signal);
+        } else if (signal?.type === SIGNAL_TYPES.ALERT) {
+          acc[1].push(signal);
+        }
         return acc;
       },
       [[], []]
@@ -197,6 +200,11 @@ const SignalSelectionNerdlet = () => {
       setSelectedAlerts((sa) => uniqueGuidsArray(sa, item, !checked));
   }, []);
 
+  const deleteItemHandler = useCallback(
+    (type, guid) => selectItemHandler(type, false, { guid }),
+    [selectItemHandler]
+  );
+
   const cancelHandler = useCallback(() => navigation.closeNerdlet(), []);
 
   const saveHandler = useCallback(async () => {
@@ -272,6 +280,7 @@ const SignalSelectionNerdlet = () => {
           selectedAlerts={selectedAlerts}
           signalsDetails={signalsDetails}
           onSelect={selectItemHandler}
+          onDelete={deleteItemHandler}
         />
         <Footer
           noFlow={!flow}

--- a/nerdlets/signal-selection/listing.js
+++ b/nerdlets/signal-selection/listing.js
@@ -5,7 +5,7 @@ import { Button, HeadingText } from 'nr1';
 
 import ListingTable from './listing-table';
 import { Signal } from '../../src/components';
-import { SIGNAL_TYPES, STATUSES } from '../../src/constants';
+import { MODES, SIGNAL_TYPES, STATUSES } from '../../src/constants';
 import { signalStatus } from '../../src/utils';
 
 const Listing = ({
@@ -16,6 +16,7 @@ const Listing = ({
   selectedAlerts = [],
   signalsDetails = {},
   onSelect,
+  onDelete,
 }) => {
   return (
     <div className="listing">
@@ -60,6 +61,8 @@ const Listing = ({
                   type: SIGNAL_TYPES.ENTITY,
                   alertSeverity,
                 })}
+                mode={MODES.EDIT}
+                onDelete={() => onDelete(SIGNAL_TYPES.ENTITY, guid)}
               />
             ))}
           </div>
@@ -78,6 +81,8 @@ const Listing = ({
                 name={signalsDetails[guid]?.name || name}
                 type={SIGNAL_TYPES.ALERT}
                 status={STATUSES.UNKNOWN}
+                mode={MODES.EDIT}
+                onDelete={() => onDelete(SIGNAL_TYPES.ALERT, guid)}
               />
             ))}
           </div>
@@ -95,6 +100,7 @@ Listing.propTypes = {
   selectedAlerts: PropTypes.array,
   signalsDetails: PropTypes.object,
   onSelect: PropTypes.func,
+  onDelete: PropTypes.func,
 };
 
 export default Listing;

--- a/src/components/signal/index.js
+++ b/src/components/signal/index.js
@@ -35,15 +35,21 @@ const Signal = ({
             }`
           : ''
       } ${
-        (selections.type === COMPONENTS.STEP && !isInSelectedStep) ||
-        (selections.type === COMPONENTS.SIGNAL && selections.id !== guid)
+        mode !== MODES.EDIT &&
+        ((selections?.type === COMPONENTS.STEP && !isInSelectedStep) ||
+          (selections?.type === COMPONENTS.SIGNAL && selections.id !== guid))
           ? 'faded'
           : ''
       }`}
-      onClick={(e) => {
-        e.stopPropagation();
-        markSelection(COMPONENTS.SIGNAL, guid, { name, type, status });
-      }}
+      onClick={
+        mode !== MODES.EDIT
+          ? (e) => {
+              e.stopPropagation();
+              if (markSelection)
+                markSelection(COMPONENTS.SIGNAL, guid, { name, type, status });
+            }
+          : null
+      }
     >
       <div className="status">
         <IconsLib

--- a/src/components/step/index.js
+++ b/src/components/step/index.js
@@ -76,7 +76,8 @@ const Step = ({
     setSignalsListView([STATUSES.CRITICAL, STATUSES.WARNING].includes(status));
   }, [stageId, levelId, stepId, stages, signals, selections]);
 
-  const updateSignalsHandler = () =>
+  const updateSignalsHandler = (e) => {
+    e.stopPropagation();
     navigation.openStackedNerdlet({
       id: 'signal-selection',
       urlState: {
@@ -89,6 +90,7 @@ const Step = ({
         stepTitle: title,
       },
     });
+  };
 
   const openDeleteModalHandler = (guid, name) => {
     signalToDelete.current = { guid, name };
@@ -186,7 +188,11 @@ const Step = ({
       className={`step ${mode === MODES.STACKED ? 'stacked' : ''} ${
         isSelected ? 'selected' : ''
       } ${status} ${isFaded ? 'faded' : ''}`}
-      onClick={() => markSelection(COMPONENTS.STEP, stepId)}
+      onClick={() =>
+        mode !== MODES.EDIT && markSelection
+          ? markSelection(COMPONENTS.STEP, stepId)
+          : null
+      }
       draggable={mode === MODES.EDIT}
       onDragStart={dragStartHandler}
       onDragOver={onDragOver}
@@ -212,7 +218,7 @@ const Step = ({
               iconType={Button.ICON_TYPE.INTERFACE__SIGN__PLUS__V_ALTERNATE}
               onClick={updateSignalsHandler}
             >
-              Add a signal
+              {`${signals.length ? 'Update' : 'Add'} signals`}
             </Button>
           </div>
           <div className="edit-signals-list">


### PR DESCRIPTION
Closes #177 

- Fixes an issue where signal-selection nerdlet crashed when existing signals where present in a step
- Also, including the delete icon for existing signals in the signal-selection nerdlet
- Disables clicks for signals and steps when in edit mode
- Fixed verbiage on edit button for signals