### PR TITLE
fix: click behavior for inline and stacked view modes

### DIFF
--- a/src/components/step/index.js
+++ b/src/components/step/index.js
@@ -73,8 +73,11 @@ const Step = ({
     setStageName(name);
     setTitle(step.title);
     setStatus(step.status || STATUSES.UNKNOWN);
-    setSignalsListView([STATUSES.CRITICAL, STATUSES.WARNING].includes(status));
   }, [stageId, levelId, stepId, stages, signals, selections]);
+
+  useEffect(() => {
+    setSignalsListView([STATUSES.CRITICAL, STATUSES.WARNING].includes(status));
+  }, [status]);
 
   const updateSignalsHandler = (e) => {
     e.stopPropagation();
@@ -152,6 +155,13 @@ const Step = ({
             guid,
             status,
             type,
+            style: {
+              opacity:
+                selections.type === COMPONENTS.SIGNAL && selections.id !== guid
+                  ? 0.3
+                  : 1.0,
+              cursor: 'pointer',
+            },
           })
         )}
       />
@@ -179,14 +189,18 @@ const Step = ({
   SignalsList.displayName = 'SignalsList';
 
   const handleStepHeaderClick = (e) => {
-    e.stopPropagation();
-    if (signals.length) setSignalsListView((slw) => !slw);
+    if (mode === MODES.INLINE) {
+      e.stopPropagation();
+      if (signals.length) setSignalsListView((slw) => !slw);
+    }
   };
 
   return (
     <div
       className={`step ${mode === MODES.STACKED ? 'stacked' : ''} ${
-        isSelected ? 'selected' : ''
+        isSelected || (selections.type === COMPONENTS.SIGNAL && !isFaded)
+          ? 'selected'
+          : ''
       } ${status} ${isFaded ? 'faded' : ''}`}
       onClick={() =>
         mode !== MODES.EDIT && markSelection


### PR DESCRIPTION
resolves #179 & #182

- inline mode
  - hovering on a signal in signal grid should change the mouse style
  - when a signal in signal grids is selected, the rest of the signals need to display as faded
  - make sure step header click expands/collapses the step only in inline mode
  - clicking on a signal in a grid would expand the step. it should not change the step display mode

- stacked mode
  - clicking on step header should behave the same as step itself and highlight the step
  - selecting a signal should highlight all steps that contain the selected signal
  - when fading other steps the borders of warning and critical steps (part of 'step-cell' css class) should fade as well
