### PR TITLE
fix: open entity/conditions in new tab in signal detail sidebar

### DIFF
--- a/src/components/signal-detail-sidebar/index.js
+++ b/src/components/signal-detail-sidebar/index.js
@@ -77,7 +77,8 @@ const SignalDetailSidebar = ({ guid, name, type, status }) => {
             {hasAccessToEntity ? (
               <Link
                 className="detail-link"
-                onClick={() => navigation.openStackedEntity(guid)}
+                to={navigation.getOpenEntityLocation(guid)}
+                onClick={(e) => e.target.setAttribute('target', '_blank')}
               >
                 {detailLinkText}
               </Link>


### PR DESCRIPTION
Closes #223 