### PR TITLE
fix: multiple playback fixes and other fixes

### DIFF
--- a/nerdlets/home/index.js
+++ b/nerdlets/home/index.js
@@ -3,6 +3,7 @@ import React, {
   useContext,
   useEffect,
   useMemo,
+  useRef,
   useState,
 } from 'react';
 
@@ -67,7 +68,6 @@ const HomeNerdlet = () => {
   const [isAuditLogShown, setisAuditLogShown] = useState(false);
   const [editFlowSettings, setEditFlowSettings] = useState(false);
   const [transitionToFlow, setTransitionToFlow] = useState(false);
-  const [transitionIntervalId, setTransitionIntervalId] = useState();
   const { accountId } = useContext(PlatformStateContext);
   const [nerdletState, setNerdletState] = useNerdletState();
   const { user } = useFetchUser();
@@ -80,12 +80,14 @@ const HomeNerdlet = () => {
     refetch: flowsRefetch,
   } = useFlowLoader({ accountId });
   const { data: accounts = [] } = useAccountsQuery();
+  const transitionTimeoutId = useRef();
 
   useEffect(() => {
     return () => {
-      if (transitionIntervalId) clearInterval(transitionIntervalId);
+      if (transitionTimeoutId.current)
+        clearTimeout(transitionTimeoutId.current);
     };
-  }, [transitionIntervalId]);
+  }, []);
 
   useEffect(
     () =>
@@ -198,11 +200,9 @@ const HomeNerdlet = () => {
 
   const transitionToMode = useCallback((newMode) => {
     setTransitionToFlow(true);
-    setTransitionIntervalId(
-      setInterval(() => {
-        setTransitionToFlow(false);
-      }, 3000)
-    );
+    transitionTimeoutId.current = setTimeout(() => {
+      setTransitionToFlow(false);
+    }, 3000);
     if (newMode) changeMode(newMode);
   }, []);
 

--- a/src/components/flow/index.js
+++ b/src/components/flow/index.js
@@ -59,19 +59,23 @@ const Flow = forwardRef(
     const [isPlayback, setIsPlayback] = useState(false);
     const [isPreview, setIsPreview] = useState(false);
     const { account: { id: accountId } = {}, user } = useContext(AppContext);
-    const { openSidebar } = useSidebar();
+    const { closeSidebar, isOpen: sidebarIsOpen, openSidebar } = useSidebar();
     const flowWriter = useFlowWriter({ accountId, user });
     const stagesRef = useRef();
+    const flowIdRef = useRef();
 
-    useEffect(
-      () =>
-        dispatch({
-          type: FLOW_DISPATCH_TYPES.CHANGED,
-          component: FLOW_DISPATCH_COMPONENTS.FLOW,
-          updates: flowDoc,
-        }),
-      [flowDoc]
-    );
+    useEffect(() => {
+      dispatch({
+        type: FLOW_DISPATCH_TYPES.CHANGED,
+        component: FLOW_DISPATCH_COMPONENTS.FLOW,
+        updates: flowDoc,
+      });
+      if (flowIdRef.current !== flowDoc.id) {
+        if (sidebarIsOpen) closeSidebar();
+        setIsPlayback(false);
+        flowIdRef.current = flowDoc.id;
+      }
+    }, [flowDoc]);
 
     useEffect(() => {
       if (isPreview) setMode(prevNonEditMode);

--- a/src/components/playback-bar/index.js
+++ b/src/components/playback-bar/index.js
@@ -88,7 +88,7 @@ const PlaybackBar = ({ onPreload, onSeek }) => {
       setDisplayBands(
         Array.from({ length: seekBandsCount.current }, (_, i) => ({
           key: uuid(),
-          style: { left: i * width, width },
+          style: { left: i * width, width: width - 1 },
         }))
       );
       const newSeekX = Math.round(seekX.current / width) * width;
@@ -172,7 +172,7 @@ const PlaybackBar = ({ onPreload, onSeek }) => {
             transform: `translateX(${newX}px)`,
           };
         });
-      }, 3000);
+      }, 1500);
     } else {
       clearInterval(intervalId.current);
     }


### PR DESCRIPTION
Closes #299  - cancel out of playback mode when flow changes
In addition,
- closes the sidebar if open, when flow changes
- adds a 1px gap between time bands in playback bar
- speeds up play in playback mode
- replaces a `setInterval` with a `setTimeout` in `nerdlets/home/index.js` 
- switched to using a ref rather than a state variable to store the interval id
