### PR TITLE
fix: step status weight settings; enhanced tooltip

### DIFF
--- a/nerdlets/signal-selection/index.js
+++ b/nerdlets/signal-selection/index.js
@@ -219,15 +219,17 @@ const SignalSelectionNerdlet = () => {
           levelId,
           stepId: step?.id,
           signals: [
-            ...(selectedEntities || []).map(({ guid, name }) => ({
+            ...(selectedEntities || []).map(({ guid, name, included }) => ({
               guid,
               name,
               type: SIGNAL_TYPES.ENTITY,
+              included: included !== undefined ? included : true,
             })),
-            ...(selectedAlerts || []).map(({ guid, name }) => ({
+            ...(selectedAlerts || []).map(({ guid, name, included }) => ({
               guid,
               name,
               type: SIGNAL_TYPES.ALERT,
+              included: included !== undefined ? included : true,
             })),
           ],
         },

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -26,3 +26,4 @@ export { default as SignalDetailSidebar } from './signal-detail-sidebar';
 export { default as SignalsGridLayout } from './signals-grid-layout';
 export { default as EmptyBlock } from './empty-block';
 export { default as PlaybackBar } from './playback-bar';
+export { default as StepSettingsModal } from './step-settings-modal';

--- a/src/components/level/index.js
+++ b/src/components/level/index.js
@@ -123,7 +123,7 @@ const Level = ({
             className={`step-cell ${
               mode === MODES.EDIT
                 ? 'edit'
-                : mode === MODES.STACKED &&
+                : [MODES.STACKED, MODES.INLINE].includes(mode) &&
                   signals?.length &&
                   [STATUSES.CRITICAL, STATUSES.WARNING].includes(status)
                 ? status

--- a/src/components/level/styles.scss
+++ b/src/components/level/styles.scss
@@ -34,7 +34,7 @@
     &.faded {
       opacity: 0.3;
     }
-    
+
     @include status-colors(
       $critical: 'critical',
       $success: 'success',

--- a/src/components/step-settings-modal/index.js
+++ b/src/components/step-settings-modal/index.js
@@ -1,0 +1,385 @@
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import PropTypes from 'prop-types';
+
+import {
+  Button,
+  DataTable,
+  DataTableHeader,
+  DataTableHeaderCell,
+  DataTableBody,
+  DataTableRow,
+  DataTableRowCell,
+  EmptyState,
+  HeadingText,
+  Icon,
+  Modal,
+  RadioGroup,
+  Radio,
+  Select,
+  SelectItem,
+  Switch,
+  TextField,
+  Tooltip,
+} from 'nr1';
+
+import DeleteConfirmModal from '../delete-confirm-modal';
+import {
+  STEP_STATUS_OPTIONS,
+  STEP_STATUS_UNITS,
+  UI_CONTENT,
+} from '../../constants';
+
+const signalTableHeader = (
+  <DataTableHeader>
+    <DataTableHeaderCell name="name" value="name">
+      Name
+    </DataTableHeaderCell>
+    <DataTableHeaderCell name="type" value="type">
+      Type
+    </DataTableHeaderCell>
+  </DataTableHeader>
+);
+
+const calculateTableHeight = (selectedCount, signalCount) => {
+  if (signalCount >= 10) {
+    return '10rows';
+  }
+
+  if (selectedCount === 0 || signalCount < 10) {
+    return `${signalCount}rows`;
+  }
+
+  return `${selectedCount}rows`;
+};
+
+const StepSettingsModal = ({
+  title,
+  stepStatusOption,
+  stepStatusValue,
+  stepStatusUnit,
+  signals,
+  hidden = true,
+  onConfirm,
+  onChange,
+  onClose,
+}) => {
+  const [deleteModalHidden, setDeleteModalHidden] = useState(true);
+  const [settingsModalHidden, setSettingsModalHidden] = useState(true);
+  const [statusWeightValue, setStatusWeightValue] = useState('');
+  const [statusOption, setStatusOption] = useState(STEP_STATUS_OPTIONS.WORST);
+  const [statusWeightUnit, setStatusWeightUnit] = useState(
+    STEP_STATUS_UNITS.PERCENT
+  );
+  const [checked, setChecked] = useState(false);
+  const [tableSettings, setTableSettings] = useState({});
+  const [selectedSignals, setSelectedSignals] = useState([]);
+  const [tableSelection, setTableSelection] = useState({});
+
+  useEffect(() => setSettingsModalHidden(hidden), [hidden]);
+  useEffect(() => setStatusOption(stepStatusOption), [stepStatusOption]);
+  useEffect(() => setStatusWeightUnit(stepStatusUnit), [stepStatusUnit]);
+
+  useEffect(() => {
+    if (!checked) {
+      setStatusWeightValue('');
+      setStatusWeightUnit(STEP_STATUS_UNITS.PERCENT);
+    } else {
+      setStatusWeightUnit(stepStatusUnit);
+    }
+  }, [checked]);
+
+  useEffect(() => {
+    if (
+      stepStatusValue !== '' &&
+      stepStatusOption &&
+      stepStatusOption === STEP_STATUS_OPTIONS.WORST
+    ) {
+      setStatusWeightValue(stepStatusValue);
+      setChecked(true);
+    }
+  }, [stepStatusValue]);
+
+  useEffect(() => {
+    const defaultSignalSelection = signals.filter((s) => {
+      return !s.included || s.included === true || s.included === undefined;
+    });
+    setTableSettings({
+      ariaLabel: 'Signals',
+      items: signals,
+    });
+    setSelectedSignals(defaultSignalSelection);
+
+    const sel = signals.reduce((acc, sig, idx) => {
+      acc[idx] = sig.included === undefined ? 'true' : sig.included;
+      return acc;
+    }, {});
+
+    if (sel) setTableSelection(sel);
+  }, [signals]);
+
+  const tableHeight = useMemo(
+    () =>
+      calculateTableHeight(Object.keys(tableSelection).length, signals.length),
+    [tableSelection, signals.length]
+  );
+
+  const closeHandler = useCallback(
+    (action) => {
+      switch (action) {
+        case 'update':
+          if (onChange) {
+            onChange({
+              statusOption: statusOption,
+              statusWeightUnit: statusWeightUnit,
+              statusWeightValue: statusWeightValue,
+              signals: selectedSignals,
+            });
+            if (onClose) onClose();
+          }
+          break;
+
+        case 'delete':
+          setDeleteModalHidden(false);
+          setSettingsModalHidden(true);
+      }
+      if (onClose) onClose();
+    },
+    [
+      onChange,
+      selectedSignals,
+      statusOption,
+      statusWeightUnit,
+      statusWeightValue,
+    ]
+  );
+
+  const onStatusChange = useCallback((e, value) => {
+    if (value === STEP_STATUS_OPTIONS.BEST) {
+      setStatusWeightUnit(STEP_STATUS_UNITS.PERCENT);
+      setStatusWeightValue('');
+      setChecked(false);
+    }
+    setStatusOption(value);
+  }, []);
+
+  const toggleApplySwitch = useCallback(() => {
+    setChecked((prevChecked) => !prevChecked);
+  }, [signals]);
+
+  const handleStatusUnitChange = useCallback((e, val) => {
+    setStatusWeightUnit(val);
+    setStatusWeightValue('');
+  }, []);
+
+  const handleStatusValueChange = useCallback(
+    (e) => {
+      const input = e.target.value;
+
+      if (statusWeightUnit === STEP_STATUS_UNITS.PERCENT) {
+        const numInput = parseInt(input);
+        if (numInput >= 1 && numInput <= 100) {
+          setStatusWeightValue(input);
+        } else if (input === '') {
+          setStatusWeightValue('');
+        }
+      }
+
+      if (statusWeightUnit === STEP_STATUS_UNITS.COUNT) {
+        const numInput = parseInt(input);
+        if (numInput >= 1 && numInput <= selectedSignals.length) {
+          setStatusWeightValue(input);
+        } else if (input === '') {
+          setStatusWeightValue('');
+        }
+      }
+    },
+    [statusWeightUnit]
+  );
+
+  const selectItemHandler = useCallback(
+    (sel) => {
+      const updatedSignals = signals.map((signal, idx) => {
+        const isSelected = sel[idx];
+        return { ...signal, included: isSelected || false };
+      });
+
+      setSelectedSignals(updatedSignals);
+
+      const updatedTable = Object.keys(sel).reduce((acc, key) => {
+        if (sel[key]) acc[key] = true;
+        return acc;
+      }, {});
+
+      setTableSelection(updatedTable);
+    },
+    [signals]
+  );
+
+  return (
+    <Modal hidden={settingsModalHidden} onClose={closeHandler}>
+      <HeadingText type={HeadingText.TYPE.HEADING_1}>
+        {UI_CONTENT.STEP.CONFIG.TITLE}
+      </HeadingText>
+      <HeadingText type={HeadingText.TYPE.HEADING_3}>{title || ''}</HeadingText>
+      <div className="step-form">
+        <div className="step-config-section">
+          <HeadingText
+            className="step-config-header"
+            type={HeadingText.TYPE.HEADING_4}
+          >
+            {UI_CONTENT.STEP.CONFIG.SELECT_SIGNALS.TITLE}
+          </HeadingText>
+          <span>{UI_CONTENT.STEP.CONFIG.SELECT_SIGNALS.DESCRIPTION}</span>
+          <br />
+          {signals.length > 0 ? (
+            <div className="signal-settings-table">
+              <DataTable
+                {...tableSettings}
+                height={tableHeight}
+                selectionType={DataTable.SELECTION_TYPE.MULTIPLE}
+                densityType={DataTable.DENSITY_TYPE.COMPACT}
+                selection={tableSelection}
+                onSelectionChange={selectItemHandler}
+              >
+                {signalTableHeader}
+                <DataTableBody>
+                  {() => (
+                    <DataTableRow>
+                      <DataTableRowCell />
+                      <DataTableRowCell />
+                    </DataTableRow>
+                  )}
+                </DataTableBody>
+              </DataTable>
+            </div>
+          ) : (
+            <EmptyState
+              type={EmptyState.TYPE.USER_CLEARED}
+              illustrationType={EmptyState.ILLUSTRATION_TYPE.ILLUSTRATION_03}
+              title={UI_CONTENT.STEP.CONFIG.EMPTY_STATE}
+            />
+          )}
+        </div>
+        <div className="step-config-section">
+          <HeadingText
+            className="step-config-header"
+            type={HeadingText.TYPE.HEADING_4}
+          >
+            {UI_CONTENT.STEP.CONFIG.STATUS_CONFIG.TITLE}
+          </HeadingText>
+          <span>{UI_CONTENT.STEP.CONFIG.STATUS_CONFIG.DESCRIPTION}</span>
+          <br />
+          <RadioGroup value={statusOption} onChange={onStatusChange}>
+            <div className="config-radio-btn">
+              <Radio
+                label={UI_CONTENT.STEP.CONFIG.STATUS_CONFIG.RADIO_WORST_LABEL}
+                value={STEP_STATUS_OPTIONS.WORST}
+              />
+              <Tooltip text={UI_CONTENT.STEP.CONFIG.TOOLTIPS.WORST}>
+                <Icon
+                  className="info-icon"
+                  type={Icon.TYPE.INTERFACE__INFO__INFO}
+                />
+              </Tooltip>
+            </div>
+            <Switch
+              className="config-switch"
+              disabled={
+                statusOption === STEP_STATUS_OPTIONS.BEST ? true : false
+              }
+              checked={checked}
+              label={UI_CONTENT.STEP.CONFIG.STATUS_CONFIG.APPLY_LABEL}
+              onChange={toggleApplySwitch}
+            />
+            <div className="worst-status-form">
+              <TextField
+                className="status-weight-value"
+                disabled={!checked}
+                name="step-percent"
+                placeholder="1"
+                value={statusWeightValue || ''}
+                onChange={handleStatusValueChange}
+              />
+              <Select
+                onChange={handleStatusUnitChange}
+                value={statusWeightUnit}
+                disabled={!checked}
+              >
+                <SelectItem value={STEP_STATUS_UNITS.PERCENT}>
+                  {UI_CONTENT.STEP.CONFIG.STATUS_CONFIG.SELECT.PERCENT}
+                </SelectItem>
+                <SelectItem value={STEP_STATUS_UNITS.COUNT}>
+                  {UI_CONTENT.STEP.CONFIG.STATUS_CONFIG.SELECT.COUNT}
+                </SelectItem>
+              </Select>
+            </div>
+            <div className="config-radio-btn">
+              <Radio
+                label={UI_CONTENT.STEP.CONFIG.STATUS_CONFIG.RADIO_BEST_LABEL}
+                value={STEP_STATUS_OPTIONS.BEST}
+              />
+              <Tooltip text={UI_CONTENT.STEP.CONFIG.TOOLTIPS.BEST}>
+                <Icon
+                  className="info-icon"
+                  type={Icon.TYPE.INTERFACE__INFO__INFO}
+                />
+              </Tooltip>
+            </div>
+          </RadioGroup>
+        </div>
+      </div>
+      <div className="step-button-bar">
+        <Button
+          type={Button.TYPE.DESTRUCTIVE}
+          onClick={() => closeHandler('delete')}
+        >
+          Delete
+        </Button>
+        <div className="right">
+          <Button
+            type={Button.TYPE.TERTIARY}
+            onClick={() => closeHandler('cancel')}
+          >
+            Cancel
+          </Button>
+          <Tooltip
+            text={
+              Object.keys(tableSelection).length === 0
+                ? UI_CONTENT.STEP.CONFIG.TOOLTIPS.SAVE_BTN
+                : ''
+            }
+          >
+            <Button
+              disabled={Object.keys(tableSelection).length === 0}
+              type={Button.TYPE.PRIMARY}
+              onClick={() => closeHandler('update')}
+            >
+              Save
+            </Button>
+          </Tooltip>
+        </div>
+      </div>
+      <DeleteConfirmModal
+        name={title}
+        type="step"
+        hidden={deleteModalHidden}
+        onConfirm={onConfirm}
+        onClose={() => setDeleteModalHidden(true)}
+      />
+    </Modal>
+  );
+};
+
+StepSettingsModal.propTypes = {
+  title: PropTypes.string,
+  stepStatusOption: PropTypes.string,
+  stepStatusValue: PropTypes.string,
+  stepStatusUnit: PropTypes.string,
+  signals: PropTypes.array,
+  hidden: PropTypes.bool,
+  onConfirm: PropTypes.func,
+  onChange: PropTypes.func,
+  onClose: PropTypes.func,
+};
+
+export default StepSettingsModal;

--- a/src/components/step-settings-modal/index.js
+++ b/src/components/step-settings-modal/index.js
@@ -97,17 +97,18 @@ const StepSettingsModal = ({
       setStatusWeightValue(stepStatusValue);
       setChecked(true);
     }
-  }, [stepStatusValue]);
+  }, [stepStatusValue, stepStatusOption]);
 
   useEffect(() => {
-    const defaultSignalSelection = signals.filter((s) => {
-      return !s.included || s.included === true || s.included === undefined;
-    });
     setTableSettings({
       ariaLabel: 'Signals',
       items: signals,
     });
-    setSelectedSignals(defaultSignalSelection);
+    setSelectedSignals(() =>
+      signals.filter((s) => {
+        return !s.included || s.included === true || s.included === undefined;
+      })
+    );
 
     const sel = signals.reduce((acc, sig, idx) => {
       acc[idx] = sig.included === undefined ? 'true' : sig.included;
@@ -164,7 +165,7 @@ const StepSettingsModal = ({
 
   const toggleApplySwitch = useCallback(() => {
     setChecked((prevChecked) => !prevChecked);
-  }, [signals]);
+  }, []);
 
   const handleStatusUnitChange = useCallback((e, val) => {
     setStatusWeightUnit(val);

--- a/src/components/step-settings-modal/styles.scss
+++ b/src/components/step-settings-modal/styles.scss
@@ -1,0 +1,50 @@
+.step-form {
+  margin: 50px 0;
+  display: flex;
+  flex-direction: column;
+
+  .step-config-section {
+    padding: 16px 0;
+  }
+
+  .step-config-header {
+    padding: 8px 0;
+  }
+
+  .signal-settings-table {
+    flex: 1;
+    overflow-y: scroll;
+    margin-top: 8px;
+  }
+
+  .config-radio-btn {
+    display: flex;
+    margin-top: 12px;
+  }
+
+  .config-switch {
+    margin-left: 24px;
+  }
+
+  .worst-status-form {
+    display: inline-flex;
+    margin-right: 8px;
+    padding: 8px 0;
+  }
+
+  .status-weight-value {
+    width: 40px;
+    margin-right: 8px;
+  }
+}
+
+.step-button-bar {
+  display: flex;
+  justify-content: space-between;
+
+  .right {
+    display: flex;
+    flex-direction: row;
+    gap: 10px;
+  }
+}

--- a/src/components/step-tooltip/index.js
+++ b/src/components/step-tooltip/index.js
@@ -10,7 +10,7 @@ import {
   PopoverTrigger,
 } from 'nr1';
 import IconsLib from '../icons-lib';
-import { SIGNAL_TYPES, UI_CONTENT } from '../../constants';
+import { SIGNAL_TYPES, STEP_STATUS_UNITS, UI_CONTENT } from '../../constants';
 
 const StepToolTip = memo(
   ({
@@ -27,25 +27,26 @@ const StepToolTip = memo(
 
     useEffect(() => {
       if (signals.length > 0) {
-        const includedSignals = signals.filter((s) => {
-          return s.included === true || s.included === undefined;
-        });
-
-        setIncludedSignals(includedSignals);
+        setIncludedSignals(() =>
+          signals.filter((s) => {
+            return s.included === true || s.included === undefined;
+          })
+        );
       }
     }, [signals]);
 
     const renderStatus = useMemo(() => {
-      if (includedSignals.length === 0) return 'No signals';
+      if (includedSignals.length === 0)
+        return UI_CONTENT.STEP.CONFIG.TOOLTIPS.UNKNOWN;
 
       let defaultMessage = `${
         stepStatusOption.charAt(0).toUpperCase() + stepStatusOption.slice(1)
       } status of ${includedSignals.length} signals`;
 
       if (stepStatusValue !== '') {
-        const unit = stepStatusUnit === 'percent' ? '%' : '';
+        const unit = stepStatusUnit === STEP_STATUS_UNITS.PERCENT ? '%' : '';
         const weightAppliedMessage =
-          stepStatusUnit === 'percent'
+          stepStatusUnit === STEP_STATUS_UNITS.PERCENT
             ? `${stepStatusValue}${unit} of `
             : `${stepStatusValue}/`;
 
@@ -72,7 +73,7 @@ const StepToolTip = memo(
           onClose={() => setViewRuleModalHidden(true)}
         >
           <div className="view-rule-header">
-            <span className={`statusIndicatorLarge ${stepStatus}`}></span>
+            <span className={`status-indicator-large ${stepStatus}`}></span>
             <HeadingText type={HeadingText.TYPE.HEADING_2}>
               {stepTitle}
             </HeadingText>
@@ -122,24 +123,24 @@ const StepToolTip = memo(
         <Popover openOnHover>
           <PopoverTrigger>{triggerElement}</PopoverTrigger>
           <PopoverBody placementType={PopoverBody.PLACEMENT_TYPE.TOP_START}>
-            <div className="StepTooltip">
-              <div className="StepTooltipHeader">
+            <div className="step-tooltip">
+              <div className="step-tooltip-header">
                 <span
-                  className={`StepTooltipHeader-statusIndicator ${stepStatus}`}
+                  className={`step-tooltip-header-statusIndicator ${stepStatus}`}
                 ></span>
                 <HeadingText
                   type={HeadingText.TYPE.HEADING_4}
-                  className="StepTooltipHeader-title"
+                  className="step-tooltip-header-title"
                 >
                   {stepTitle}
                 </HeadingText>
               </div>
-              <div className="StepTooltipContent">
-                <span className="StepTooltipContent-overview">
+              <div className="step-tooltip-content">
+                <span className="step-tooltip-content-overview">
                   {renderStatus}
                 </span>
                 <Link
-                  className="StepTooltipContent-viewRule"
+                  className="step-tooltip-content-viewRule"
                   onClick={() => setViewRuleModalHidden(false)}
                 >
                   {UI_CONTENT.STEP.CONFIG.TOOLTIPS.VIEW_RULE}

--- a/src/components/step-tooltip/index.js
+++ b/src/components/step-tooltip/index.js
@@ -88,7 +88,7 @@ const StepToolTip = memo(
             {includedSignals.length > 0
               ? includedSignals.map((s, i) => {
                   return (
-                    <div key={i} className="view-rule-content inclusionList">
+                    <div key={i} className="view-rule-content inclusion-list">
                       <p>
                         <IconsLib
                           className={`icons-lib ${s.status}`}
@@ -126,7 +126,7 @@ const StepToolTip = memo(
             <div className="step-tooltip">
               <div className="step-tooltip-header">
                 <span
-                  className={`step-tooltip-header-statusIndicator ${stepStatus}`}
+                  className={`step-tooltip-header-status-indicator ${stepStatus}`}
                 ></span>
                 <HeadingText
                   type={HeadingText.TYPE.HEADING_4}
@@ -140,7 +140,7 @@ const StepToolTip = memo(
                   {renderStatus}
                 </span>
                 <Link
-                  className="step-tooltip-content-viewRule"
+                  className="step-tooltip-content-view-rule"
                   onClick={() => setViewRuleModalHidden(false)}
                 >
                   {UI_CONTENT.STEP.CONFIG.TOOLTIPS.VIEW_RULE}

--- a/src/components/step-tooltip/index.js
+++ b/src/components/step-tooltip/index.js
@@ -1,0 +1,169 @@
+import React, { memo, useEffect, useMemo, useState } from 'react';
+import PropTypes from 'prop-types';
+
+import {
+  HeadingText,
+  Link,
+  Modal,
+  Popover,
+  PopoverBody,
+  PopoverTrigger,
+} from 'nr1';
+import IconsLib from '../icons-lib';
+import { SIGNAL_TYPES, UI_CONTENT } from '../../constants';
+
+const StepToolTip = memo(
+  ({
+    stepTitle,
+    stepStatus,
+    stepStatusOption,
+    stepStatusUnit,
+    stepStatusValue,
+    signals,
+    triggerElement,
+  }) => {
+    const [includedSignals, setIncludedSignals] = useState([]);
+    const [viewRuleModalHidden, setViewRuleModalHidden] = useState(true);
+
+    useEffect(() => {
+      if (signals.length > 0) {
+        const includedSignals = signals.filter((s) => {
+          return s.included === true || s.included === undefined;
+        });
+
+        setIncludedSignals(includedSignals);
+      }
+    }, [signals]);
+
+    const renderStatus = useMemo(() => {
+      if (includedSignals.length === 0) return 'No signals';
+
+      let defaultMessage = `${
+        stepStatusOption.charAt(0).toUpperCase() + stepStatusOption.slice(1)
+      } status of ${includedSignals.length} signals`;
+
+      if (stepStatusValue !== '') {
+        const unit = stepStatusUnit === 'percent' ? '%' : '';
+        const weightAppliedMessage =
+          stepStatusUnit === 'percent'
+            ? `${stepStatusValue}${unit} of `
+            : `${stepStatusValue}/`;
+
+        defaultMessage = `${
+          stepStatusOption.charAt(0).toUpperCase() + stepStatusOption.slice(1)
+        } status - ${weightAppliedMessage}${includedSignals.length} signals`;
+
+        return `${defaultMessage}`;
+      }
+
+      return defaultMessage;
+    }, [
+      stepTitle,
+      stepStatusOption,
+      stepStatusUnit,
+      stepStatusValue,
+      includedSignals,
+    ]);
+
+    const renderRuleModal = useMemo(() => {
+      return (
+        <Modal
+          hidden={viewRuleModalHidden}
+          onClose={() => setViewRuleModalHidden(true)}
+        >
+          <div className="view-rule-header">
+            <span className={`statusIndicatorLarge ${stepStatus}`}></span>
+            <HeadingText type={HeadingText.TYPE.HEADING_2}>
+              {stepTitle}
+            </HeadingText>
+          </div>
+          <div className="view-rule-content">
+            <HeadingText
+              className="view-rule-content header"
+              type={HeadingText.TYPE.HEADING_4}
+            >
+              {renderStatus}
+            </HeadingText>
+            {includedSignals.length > 0
+              ? includedSignals.map((s, i) => {
+                  return (
+                    <div key={i} className="view-rule-content inclusionList">
+                      <p>
+                        <IconsLib
+                          className={`icons-lib ${s.status}`}
+                          type={
+                            s.type === SIGNAL_TYPES.ALERT
+                              ? IconsLib.TYPES.ALERT
+                              : IconsLib.TYPES.ENTITY
+                          }
+                          shouldShowTitle={false}
+                        />
+                        <span title={s.name}>{s.name}</span>
+                      </p>
+                    </div>
+                  );
+                })
+              : ''}
+          </div>
+        </Modal>
+      );
+    }, [
+      stepTitle,
+      stepStatus,
+      stepStatusOption,
+      stepStatusUnit,
+      stepStatusValue,
+      includedSignals,
+      viewRuleModalHidden,
+    ]);
+
+    return (
+      <>
+        <Popover openOnHover>
+          <PopoverTrigger>{triggerElement}</PopoverTrigger>
+          <PopoverBody placementType={PopoverBody.PLACEMENT_TYPE.TOP_START}>
+            <div className="StepTooltip">
+              <div className="StepTooltipHeader">
+                <span
+                  className={`StepTooltipHeader-statusIndicator ${stepStatus}`}
+                ></span>
+                <HeadingText
+                  type={HeadingText.TYPE.HEADING_4}
+                  className="StepTooltipHeader-title"
+                >
+                  {stepTitle}
+                </HeadingText>
+              </div>
+              <div className="StepTooltipContent">
+                <span className="StepTooltipContent-overview">
+                  {renderStatus}
+                </span>
+                <Link
+                  className="StepTooltipContent-viewRule"
+                  onClick={() => setViewRuleModalHidden(false)}
+                >
+                  {UI_CONTENT.STEP.CONFIG.TOOLTIPS.VIEW_RULE}
+                </Link>
+              </div>
+            </div>
+          </PopoverBody>
+        </Popover>
+        {renderRuleModal}
+      </>
+    );
+  }
+);
+
+StepToolTip.propTypes = {
+  stepTitle: PropTypes.string,
+  stepStatus: PropTypes.string,
+  stepStatusOption: PropTypes.string,
+  stepStatusUnit: PropTypes.string,
+  stepStatusValue: PropTypes.string,
+  signals: PropTypes.array,
+  triggerElement: PropTypes.element,
+};
+
+StepToolTip.displayName = 'StepToolTip';
+
+export default StepToolTip;

--- a/src/components/step-tooltip/styles.scss
+++ b/src/components/step-tooltip/styles.scss
@@ -1,0 +1,154 @@
+.StepTooltip {
+  background-color: #202d32;
+  box-shadow: rgba(#283636, 0.15) 16px 8px 32px;
+  box-sizing: border-box;
+  padding: 4px 0;
+  //width: 324px;
+  display: inline-block;
+  white-space: nowrap;
+  z-index: 10;
+}
+
+.StepTooltipHeader {
+  border-bottom: #e7e9ea 1px solid;
+  align-items: baseline;
+  margin-left: 8px;
+  margin-right: 8px;
+  padding-bottom: calc(8px);
+  padding-left: 8px;
+  display: flex;
+
+  &-statusIndicator {
+    display: inline-block;
+    flex-grow: 0;
+    flex-shrink: 0;
+    height: 8px;
+    position: relative;
+    text-decoration: none;
+    white-space: nowrap;
+    width: 8px;
+
+    &.success {
+      background-color: #01a76a;
+    }
+
+    &.critical {
+      background-color: #f5554b;
+    }
+
+    &.warning {
+      background-color: #ffd23d;
+    }
+
+    &.unknown {
+      background-color: #9ea5a9;
+    }
+  }
+
+  &-title {
+    color: #f1f5f5;
+    flex: 1;
+    font-size: 12px;
+    margin-left: 4px;
+    display: inline;
+  }
+
+}
+
+.StepTooltipContent {
+  display: inline-flex;
+  margin-top: 4px;
+  margin-left: 8px;
+  margin-right: 8px;
+  padding-bottom: calc(8px);
+  padding-left: 8px;
+  padding-right: 0;
+  color: #f1f5f5;
+
+  &-overview {
+    &::after {
+      border-right: 1px solid;
+      content: '';
+      height: 100%;
+      margin-left: 4px;
+    }
+  }
+
+  &-viewRule {
+    margin-left: 4px;
+    cursor: pointer;
+  }
+}
+
+.view-rule-header {
+  display: flex;
+  align-items: baseline;
+  margin-bottom: 24px;
+}
+
+.view-rule-content {
+  padding: 4px 0 0 0;
+
+  &.header {
+    margin-bottom: 4px;
+  }
+
+  span {
+    margin-bottom: 8px;
+  }
+
+  &.inclusionList {
+    display: flex;
+
+    p {
+      margin-left: -8px;
+    }
+
+    span {
+      margin-left: 8px;
+      font-size: 12px;
+      font-weight: 400;
+      white-space: nowrap;
+      padding: 4px 0 0 0;
+    }
+
+    .icons-lib {
+      width: 16px;
+      height: 16px;
+      @include fill-colors(
+        $critical: 'critical',
+        $success: 'success',
+        $unknown: 'unknown',
+        $warning: 'warning',
+      );
+    }
+  }
+}
+
+.statusIndicatorLarge {
+  display: inline-block;
+  flex-grow: 0;
+  flex-shrink: 0;
+  height: 16px;
+  position: relative;
+  text-decoration: none;
+  white-space: nowrap;
+  width: 16px;
+  margin-right: 8px;
+
+  &.success {
+    background-color: #01a76a;
+  }
+
+  &.critical {
+    background-color: #f5554b;
+  }
+
+  &.warning {
+    background-color: #ffd23d;
+  }
+
+  &.unknown {
+    background-color: #9ea5a9;
+  }
+}

--- a/src/components/step-tooltip/styles.scss
+++ b/src/components/step-tooltip/styles.scss
@@ -1,15 +1,14 @@
-.StepTooltip {
+.step-tooltip {
   background-color: #202d32;
   box-shadow: rgba(#283636, 0.15) 16px 8px 32px;
   box-sizing: border-box;
   padding: 4px 0;
-  //width: 324px;
   display: inline-block;
   white-space: nowrap;
   z-index: 10;
 }
 
-.StepTooltipHeader {
+.step-tooltip-header {
   border-bottom: #e7e9ea 1px solid;
   align-items: baseline;
   margin-left: 8px;
@@ -55,7 +54,7 @@
 
 }
 
-.StepTooltipContent {
+.step-tooltip-content {
   display: inline-flex;
   margin-top: 4px;
   margin-left: 8px;
@@ -125,7 +124,7 @@
   }
 }
 
-.statusIndicatorLarge {
+.status-indicator-large {
   display: inline-block;
   flex-grow: 0;
   flex-shrink: 0;

--- a/src/components/step-tooltip/styles.scss
+++ b/src/components/step-tooltip/styles.scss
@@ -17,7 +17,7 @@
   padding-left: 8px;
   display: flex;
 
-  &-statusIndicator {
+  &-status-indicator {
     display: inline-block;
     flex-grow: 0;
     flex-shrink: 0;
@@ -73,7 +73,7 @@
     }
   }
 
-  &-viewRule {
+  &-view-rule {
     margin-left: 4px;
     cursor: pointer;
   }
@@ -96,7 +96,7 @@
     margin-bottom: 8px;
   }
 
-  &.inclusionList {
+  &.inclusion-list {
     display: flex;
 
     p {

--- a/src/components/step/header.js
+++ b/src/components/step/header.js
@@ -1,12 +1,14 @@
-import React, { useContext, useEffect, useState } from 'react';
+import React, { useCallback, useContext, useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 
-import { HeadingText, Icon } from 'nr1';
+import { HeadingText, Icon, Popover, PopoverBody, PopoverTrigger } from 'nr1';
 import { EditInPlace } from '@newrelic/nr-labs-components';
 
 import IconsLib from '../icons-lib';
 import DeleteConfirmModal from '../delete-confirm-modal';
-import { MODES } from '../../constants';
+import StepSettingsModal from '../step-settings-modal';
+import StepToolTip from '../step-tooltip';
+import { MODES, STATUSES } from '../../constants';
 import { FlowDispatchContext, StagesContext } from '../../contexts';
 import { FLOW_DISPATCH_COMPONENTS, FLOW_DISPATCH_TYPES } from '../../reducers';
 
@@ -22,14 +24,25 @@ const StepHeader = ({
   const { stages } = useContext(StagesContext);
   const dispatch = useContext(FlowDispatchContext);
   const [title, setTitle] = useState();
+  const [status, setStatus] = useState(STATUSES.UNKNOWN);
+  const [signals, setSignals] = useState([]);
+  const [stepStatusValue, setStepStatusValue] = useState(null);
+  const [stepStatusOption, setStepStatusOption] = useState(null);
+  const [stepStatusUnit, setStepStatusUnit] = useState(null);
+  const [settingsModalHidden, setSettingsModalHidden] = useState(true);
   const [deleteModalHidden, setDeleteModalHidden] = useState(true);
 
   useEffect(() => {
     const { levels = [] } =
       (stages || []).find(({ id }) => id === stageId) || {};
     const { steps = [] } = levels.find(({ id }) => id === levelId) || {};
-    const { title: stepTitle } = steps.find(({ id }) => id === stepId) || {};
-    setTitle(stepTitle);
+    const step = steps.find(({ id }) => id === stepId) || {};
+    setTitle(step.title);
+    setStatus(step.status || STATUSES.UNKNOWN);
+    setSignals(step.signals || []);
+    setStepStatusValue(step.statusWeightValue || '');
+    setStepStatusOption(step.statusOption || 'worst');
+    setStepStatusUnit(step.statusWeightUnit || 'percent');
   }, [stageId, levelId, stepId, stages]);
 
   const updateTitleHandler = (newTitle) => {
@@ -43,6 +56,16 @@ const StepHeader = ({
     });
   };
 
+  const updateStepHandler = (updates = {}) => {
+    dispatch({
+      type: FLOW_DISPATCH_TYPES.UPDATED,
+      component: FLOW_DISPATCH_COMPONENTS.STEP,
+      componentIds: { stageId, levelId, stepId },
+      updates,
+      saveFlow,
+    });
+  };
+
   const deleteStepHandler = () =>
     dispatch({
       type: FLOW_DISPATCH_TYPES.DELETED,
@@ -50,6 +73,17 @@ const StepHeader = ({
       componentIds: { stageId, levelId, stepId },
       saveFlow,
     });
+
+  const linkClickHandler = useCallback((e, type) => {
+    e.preventDefault();
+    e.stopPropagation();
+
+    if (type === 'delete') {
+      setDeleteModalHidden(false);
+    } else if (type === 'settings') {
+      setSettingsModalHidden(false);
+    }
+  }, []);
 
   return mode === MODES.EDIT ? (
     <div className="step-header edit">
@@ -63,8 +97,26 @@ const StepHeader = ({
       <HeadingText type={HeadingText.TYPE.HEADING_6} className="title">
         <EditInPlace value={title} setValue={updateTitleHandler} />
       </HeadingText>
-      <span className="delete-btn" onClick={() => setDeleteModalHidden(false)}>
-        <Icon type={Icon.TYPE.INTERFACE__OPERATIONS__CLOSE} />
+      <span className="last-col">
+        <Popover>
+          <PopoverTrigger>
+            <Icon type={Icon.TYPE.INTERFACE__OPERATIONS__MORE} />
+          </PopoverTrigger>
+          <PopoverBody placementType={PopoverBody.PLACEMENT_TYPE.BOTTOM_END}>
+            <div className="dropdown-links">
+              <div className="dropdown-link">
+                <a href="#" onClick={(e) => linkClickHandler(e, 'settings')}>
+                  Settings
+                </a>
+              </div>
+              <div className="dropdown-link destructive">
+                <a href="#" onClick={(e) => linkClickHandler(e, 'delete')}>
+                  Delete step
+                </a>
+              </div>
+            </div>
+          </PopoverBody>
+        </Popover>
       </span>
       <DeleteConfirmModal
         name={title}
@@ -73,12 +125,33 @@ const StepHeader = ({
         onConfirm={deleteStepHandler}
         onClose={() => setDeleteModalHidden(true)}
       />
+      <StepSettingsModal
+        title={title}
+        stepStatusOption={stepStatusOption}
+        stepStatusValue={stepStatusValue}
+        stepStatusUnit={stepStatusUnit}
+        signals={signals}
+        hidden={settingsModalHidden}
+        onConfirm={deleteStepHandler}
+        onChange={updateStepHandler}
+        onClose={() => setSettingsModalHidden(true)}
+      />
     </div>
   ) : (
-    <div className="step-header" onClick={handleStepHeaderClick} title={title}>
-      <HeadingText type={HeadingText.TYPE.HEADING_6} className="title">
-        {title}
-      </HeadingText>
+    <div className="step-header" onClick={handleStepHeaderClick}>
+      <StepToolTip
+        stepTitle={title}
+        stepStatus={status}
+        stepStatusOption={stepStatusOption}
+        stepStatusValue={stepStatusValue}
+        stepStatusUnit={stepStatusUnit}
+        signals={signals}
+        triggerElement={
+          <HeadingText type={HeadingText.TYPE.HEADING_6} className="title">
+            {title}
+          </HeadingText>
+        }
+      />
     </div>
   );
 };

--- a/src/components/step/index.js
+++ b/src/components/step/index.js
@@ -197,7 +197,9 @@ const Step = ({
         isSelected || (selections.type === COMPONENTS.SIGNAL && !isFaded)
           ? 'selected'
           : ''
-      } ${mode !== MODES.INLINE ? status : ''} ${isFaded ? 'faded' : ''}`}
+      } ${[MODES.STACKED, MODES.INLINE].includes(mode) ? status : ''} ${
+        isFaded ? 'faded' : ''
+      }`}
       onClick={() =>
         mode !== MODES.EDIT && markSelection
           ? markSelection(COMPONENTS.STEP, stepId)
@@ -213,6 +215,7 @@ const Step = ({
         stageId={stageId}
         levelId={levelId}
         stepId={stepId}
+        signals={signals}
         onDelete={onDelete}
         onDragHandle={dragHandleHandler}
         mode={mode}

--- a/src/components/styles.scss
+++ b/src/components/styles.scss
@@ -27,3 +27,5 @@
 @import './empty-block/styles.scss';
 @import './playback-bar/styles.scss';
 @import './signal-tooltip/styles.scss';
+@import './step-settings-modal/styles.scss';
+@import './step-tooltip/styles.scss';

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -9,3 +9,4 @@ export * from './nrql';
 export * from './app';
 export * from './datetime';
 export * from './alerts';
+export * from './steps';

--- a/src/constants/steps.js
+++ b/src/constants/steps.js
@@ -1,0 +1,9 @@
+export const STEP_STATUS_OPTIONS = {
+  BEST: 'best',
+  WORST: 'worst',
+};
+
+export const STEP_STATUS_UNITS = {
+  PERCENT: 'percent',
+  COUNT: 'count',
+};

--- a/src/constants/ui-content.js
+++ b/src/constants/ui-content.js
@@ -79,6 +79,35 @@ export const UI_CONTENT = {
       TITLE: 'No signals yet',
       DESCRIPTION:
         'A signal is an entity or alert that reflects the underlying health of its parent step.',
+      EMPTY_STATE: 'No signals attached to step',
+    },
+    CONFIG: {
+      TITLE: 'Step Settings',
+      SELECT_SIGNALS: {
+        TITLE: 'Select Signals',
+        DESCRIPTION:
+          'Signals selected will be included in step status determination. Defaults to all signals.',
+      },
+      STATUS_CONFIG: {
+        TITLE: 'Status Configuration',
+        DESCRIPTION:
+          "Determine step status by the worst or best selected signals' status.",
+        RADIO_WORST_LABEL: 'Rollup the worst status',
+        RADIO_BEST_LABEL: 'Rollup the best status',
+        APPLY_LABEL: 'Apply only when',
+        SELECT: {
+          PERCENT: '% of signals',
+          COUNT: 'signals',
+        },
+      },
+      EMPTY_STATE: 'No signals attached to step',
+      TOOLTIPS: {
+        WORST:
+          'Step status matches signals in a unhealthy state. Optionally, use the toggle below to apply the status only if a minimum percent or count of signals are unhealthy',
+        BEST: 'Step status matches signals in a healthy state first. Use this to keep step status healthy as long as one signal is healthy',
+        SAVE_BTN: 'At least 1 signal must be selected',
+        VIEW_RULE: 'View Rule Details',
+      },
     },
   },
   SIGNAL: {

--- a/src/constants/ui-content.js
+++ b/src/constants/ui-content.js
@@ -106,6 +106,7 @@ export const UI_CONTENT = {
           'Step status matches signals in a unhealthy state. Optionally, use the toggle below to apply the status only if a minimum percent or count of signals are unhealthy',
         BEST: 'Step status matches signals in a healthy state first. Use this to keep step status healthy as long as one signal is healthy',
         SAVE_BTN: 'At least 1 signal must be selected',
+        UNKNOWN: 'No signals',
         VIEW_RULE: 'View Rule Details',
       },
     },


### PR DESCRIPTION
- Step weight configuration - Allows to include/exclude signals from step weight calculation, as well as signal rollup options
- Enhanced step tooltip - Includes quick detail in step status config and a drilldown into currently selected signals contributing to step status determination
- Added status outline to `Inline` view of step cells