### PR TITLE
fix: replace edit-in-place component to support i18n

### DIFF
--- a/src/components/edit-in-place/index.js
+++ b/src/components/edit-in-place/index.js
@@ -1,0 +1,77 @@
+import React, {
+  forwardRef,
+  useCallback,
+  useEffect,
+  useImperativeHandle,
+  useRef,
+  useState,
+} from 'react';
+import PropTypes from 'prop-types';
+
+const PLACEHOLDER_TEXT = 'Untitled';
+
+const EditInPlace = forwardRef(
+  ({ value, setValue, placeholder, disabled = false }, ref) => {
+    const [isEditing, setIsEditing] = useState(false);
+    const [text, setText] = useState('');
+    const [inputWidth, setInputWidth] = useState(0);
+    const editableRef = useRef();
+    const contentRef = useRef();
+
+    useImperativeHandle(
+      ref,
+      () => ({
+        focus: editableRef.current?.focus?.(),
+      }),
+      []
+    );
+
+    useEffect(() => setText(value), [value]);
+
+    const editHandler = useCallback(() => {
+      setInputWidth(contentRef.current?.offsetWidth || 0);
+      setIsEditing(true);
+    }, []);
+
+    const blurHandler = useCallback(() => {
+      setValue?.((text || '').replace(/[\s\u00A0]+/g, ' ').trim());
+      setIsEditing(false);
+    }, [text, setValue]);
+
+    return isEditing && !disabled ? (
+      <input
+        ref={editableRef}
+        autoFocus
+        className="eip-input u-unstyledInput"
+        placeholder={placeholder || PLACEHOLDER_TEXT}
+        onBlur={blurHandler}
+        onChange={({ target: { value: v = '' } = {} } = {}) => setText(v)}
+        onKeyDown={(e) =>
+          e?.key === 'Enter' && !e?.isComposing ? blurHandler() : null
+        }
+        value={text}
+        style={{ width: inputWidth }}
+      />
+    ) : (
+      <div
+        ref={contentRef}
+        className="eip-content"
+        data-placeholder={text ? '' : placeholder || PLACEHOLDER_TEXT}
+        onClick={editHandler}
+      >
+        {value}
+      </div>
+    );
+  }
+);
+
+EditInPlace.propTypes = {
+  value: PropTypes.string,
+  setValue: PropTypes.func,
+  placeholder: PropTypes.string,
+  disabled: PropTypes.bool,
+};
+
+EditInPlace.displayName = 'EditInPlace';
+
+export default EditInPlace;

--- a/src/components/edit-in-place/styles.scss
+++ b/src/components/edit-in-place/styles.scss
@@ -1,0 +1,23 @@
+.eip-content {
+  border: 1px solid transparent;
+  cursor: text;
+  outline: none;
+  transition: 250ms all ease;
+
+  &:hover {
+    border-color: #F3F4F4;
+  }
+
+  &::before {
+    content: attr(data-placeholder);
+    opacity: 0.5;
+    color: inherit;
+  }
+}
+
+.eip-input {
+  all: inherit;
+  display: inline-block;
+  border: 1px solid transparent;
+  transition: 250ms all ease;
+}

--- a/src/components/flow/header.js
+++ b/src/components/flow/header.js
@@ -14,10 +14,14 @@ import {
   SegmentedControlItem,
   Tooltip,
 } from 'nr1';
-import { EditInPlace } from '@newrelic/nr-labs-components';
 
-import IconsLib from '../icons-lib';
-import { FlowListDropdown, ImageUploadModal, LastSavedMessage } from '../';
+import {
+  EditInPlace,
+  IconsLib,
+  FlowListDropdown,
+  ImageUploadModal,
+  LastSavedMessage,
+} from '../';
 import { MODES, UI_CONTENT } from '../../constants';
 
 const FlowHeader = ({

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -29,3 +29,4 @@ export { default as PlaybackBar } from './playback-bar';
 export { default as StepSettingsModal } from './step-settings-modal';
 export { default as SignalTooltip } from './signal-tooltip';
 export { default as StepDetailSidebar } from './step-detail-sidebar';
+export { default as EditInPlace } from './edit-in-place';

--- a/src/components/kpi-modal/index.js
+++ b/src/components/kpi-modal/index.js
@@ -11,17 +11,14 @@ import {
   PopoverBody,
 } from 'nr1';
 
-import {
-  EditInPlace,
-  NrqlEditor,
-  SimpleBillboard,
-} from '@newrelic/nr-labs-components';
+import { NrqlEditor, SimpleBillboard } from '@newrelic/nr-labs-components';
 
 import KpiModalDeleteContent from './delete';
 import KpiModalEmptyState from './empty';
+import { EditInPlace } from '../';
 import { useFetchKpis } from '../../hooks';
-import { KPI_MODES, UI_CONTENT } from '../../constants';
 import { lexer, NRQL_STYLES, formatKpiHoverDatime } from '../../utils';
+import { KPI_MODES, UI_CONTENT } from '../../constants';
 
 const metricFromQuery = (results) => ({
   value: results?.value || 0,

--- a/src/components/stage/header.js
+++ b/src/components/stage/header.js
@@ -2,11 +2,15 @@ import React, { useCallback, useMemo, useState } from 'react';
 import PropTypes from 'prop-types';
 
 import { HeadingText, Icon, Popover, PopoverTrigger, PopoverBody } from 'nr1';
-import { EditInPlace } from '@newrelic/nr-labs-components';
 
-import { IconsLib, DeleteConfirmModal, StageSettingsModal } from '../';
-import { MODES, STATUSES, UI_CONTENT } from '../../constants';
+import {
+  IconsLib,
+  DeleteConfirmModal,
+  StageSettingsModal,
+  EditInPlace,
+} from '../';
 import { stageHeaderShapeClassName } from '../../utils';
+import { MODES, STATUSES, UI_CONTENT } from '../../constants';
 
 const StageHeader = ({
   name,

--- a/src/components/step/header.js
+++ b/src/components/step/header.js
@@ -9,12 +9,16 @@ import {
   PopoverBody,
   PopoverTrigger,
 } from 'nr1';
-import { EditInPlace } from '@newrelic/nr-labs-components';
 
-import { IconsLib, DeleteConfirmModal, StepSettingsModal } from '../';
-import { MODES } from '../../constants';
-import { FlowDispatchContext } from '../../contexts';
+import {
+  IconsLib,
+  DeleteConfirmModal,
+  StepSettingsModal,
+  EditInPlace,
+} from '../';
 import { FLOW_DISPATCH_COMPONENTS, FLOW_DISPATCH_TYPES } from '../../reducers';
+import { FlowDispatchContext } from '../../contexts';
+import { MODES } from '../../constants';
 
 const StepHeader = ({
   stageId,

--- a/src/components/styles.scss
+++ b/src/components/styles.scss
@@ -29,3 +29,4 @@
 @import './signal-tooltip/styles.scss';
 @import './step-settings-modal/styles.scss';
 @import './step-detail-sidebar/styles.scss';
+@import './edit-in-place/styles.scss';


### PR DESCRIPTION
Closes #441 

- switch the `EditInPlace` component from `nr-labs-components` to a local one for i18n support