### PR TITLE
fix: display message when alerting service level has no incidents

### DIFF
--- a/src/components/signal-detail-sidebar/incidents.js
+++ b/src/components/signal-detail-sidebar/incidents.js
@@ -102,6 +102,14 @@ const Incidents = ({ type, data, timeWindow }) => {
       </HeadingText>
       <div className="alert-incidents">
         {bannerMessage && <SectionMessage description={bannerMessage} />}
+        {data?.type === 'SERVICE_LEVEL' &&
+        data?.alertSeverity !== 'NOT_ALERTING' &&
+        !incidentsList?.length ? (
+          <SectionMessage
+            type={SectionMessage.TYPE.WARNING}
+            description={UI_CONTENT.SIGNAL.DETAILS.ALERTING_SL_NO_INCIDENT}
+          />
+        ) : null}
         {incidentsList.reduce(
           (
             acc,

--- a/src/constants/ui-content.js
+++ b/src/constants/ui-content.js
@@ -137,6 +137,7 @@ export const UI_CONTENT = {
       NO_RECENT_INCIDENTS: 'No open incidents to display.',
       LATEST_RECENT_INCIDENT:
         'No open incidents. Showing the most recent incident.',
+      ALERTING_SL_NO_INCIDENT: 'No incidents for this alerting service level!',
     },
     TOOLTIP: {
       WORKLOAD_UNKNOWN: 'The status of this workload is unknown',

--- a/src/constants/ui-content.js
+++ b/src/constants/ui-content.js
@@ -137,7 +137,7 @@ export const UI_CONTENT = {
       NO_RECENT_INCIDENTS: 'No open incidents to display.',
       LATEST_RECENT_INCIDENT:
         'No open incidents. Showing the most recent incident.',
-      ALERTING_SL_NO_INCIDENT: 'No incidents for this alerting service level!',
+      ALERTING_SL_NO_INCIDENT: 'This Service Level is in an unhealthy state, however we can\'t find any correlated incidents. It is likely that the Service Level is out of compliance - to investigate further, please open the entity view (linked above).',
     },
     TOOLTIP: {
       WORKLOAD_UNKNOWN: 'The status of this workload is unknown',

--- a/src/constants/ui-content.js
+++ b/src/constants/ui-content.js
@@ -137,7 +137,8 @@ export const UI_CONTENT = {
       NO_RECENT_INCIDENTS: 'No open incidents to display.',
       LATEST_RECENT_INCIDENT:
         'No open incidents. Showing the most recent incident.',
-      ALERTING_SL_NO_INCIDENT: 'This Service Level is in an unhealthy state, however we can\'t find any correlated incidents. It is likely that the Service Level is out of compliance - to investigate further, please open the entity view (linked above).',
+      ALERTING_SL_NO_INCIDENT:
+        "This Service Level is in an unhealthy state, however we can't find any correlated incidents. It is likely that the Service Level is out of compliance - to investigate further, please open the entity view (linked above).",
     },
     TOOLTIP: {
       WORKLOAD_UNKNOWN: 'The status of this workload is unknown',


### PR DESCRIPTION
Closes #451 

- display message in signal detail sidebar for alerting service levels with no incidents