### PR TITLE
fix: missing color for high issue; also change verbiage for link

### DIFF
--- a/src/components/signal-detail-sidebar/incidents.js
+++ b/src/components/signal-detail-sidebar/incidents.js
@@ -143,7 +143,7 @@ const Incidents = ({ type, data, timeWindow }) => {
                               e.target.setAttribute('target', '_blank')
                             }
                           >
-                            View incident
+                            View issue
                           </Link>
                         </div>
                         <div>Started: {formatTimestamp(opened)}</div>

--- a/src/components/signal-detail-sidebar/styles.scss
+++ b/src/components/signal-detail-sidebar/styles.scss
@@ -70,7 +70,7 @@
               background: $critical;
             }
 
-            &.warning {
+            &.warning, &.high {
               background: $warning;
             }
 

--- a/src/components/signal-detail-sidebar/styles.scss
+++ b/src/components/signal-detail-sidebar/styles.scss
@@ -92,7 +92,7 @@
               color: $critical;
             }
 
-            &.warning {
+            &.warning, &.high {
               color: $alt-warning;
             }
 


### PR DESCRIPTION
Closes #473 
Also closes #321 

- update verbiage for `View incident` link to `View issue`
- fixes missing icon/color for alert condition in `high` status