### PR TITLE
fix: add export flow modal

### DIFF
--- a/nerdlets/home/index.js
+++ b/nerdlets/home/index.js
@@ -20,11 +20,17 @@ import {
 } from 'nr1';
 import { HelpModal, Messages } from '@newrelic/nr-labs-components';
 
-import { Flow, FlowList, NoFlows, Sidebar } from '../../src/components';
+import {
+  ExportFlowModal,
+  Flow,
+  FlowList,
+  NoFlows,
+  Sidebar,
+} from '../../src/components';
 import { useFlowLoader, useFetchUser } from '../../src/hooks';
-import { exportFlowDoc, flowDocument } from '../../src/utils';
-import { MAX_ENTITIES_IN_STEP, MODES, UI_CONTENT } from '../../src/constants';
 import { AppContext, SidebarProvider } from '../../src/contexts';
+import { flowDocument } from '../../src/utils';
+import { MAX_ENTITIES_IN_STEP, MODES, UI_CONTENT } from '../../src/constants';
 
 const ACTION_BTN_ATTRIBS = {
   CREATE_FLOW: {
@@ -66,6 +72,7 @@ const HomeNerdlet = () => {
   const [isHelpModalShown, setIsHelpModalShown] = useState(false);
   const [editFlowSettings, setEditFlowSettings] = useState(false);
   const [transitionToFlow, setTransitionToFlow] = useState(false);
+  const [isExportFlowModalShown, setIsExportFlowModalShown] = useState(false);
   const { accountId } = useContext(PlatformStateContext);
   const [nerdletState, setNerdletState] = useNerdletState();
   const { user } = useFetchUser();
@@ -144,7 +151,7 @@ const HomeNerdlet = () => {
               },
               {
                 ...ACTION_BTN_ATTRIBS.EXPORT_FLOW,
-                onClick: () => exportFlowDoc(flows, currentFlowId),
+                onClick: () => setIsExportFlowModalShown(true),
               },
               {
                 ...ACTION_BTN_ATTRIBS.AUDIT_LOG,
@@ -216,6 +223,8 @@ const HomeNerdlet = () => {
   }, []);
 
   const auditLogCloseHandler = () => setisAuditLogShown(false);
+
+  const exportModalCloseHandler = () => setIsExportFlowModalShown(false);
 
   const currentFlowDoc = useMemo(
     () => (currentFlowId ? flowDocument(flows, currentFlowId) : null),
@@ -302,6 +311,11 @@ const HomeNerdlet = () => {
           ownerBadge={UI_CONTENT.HELP_MODAL.OWNER_BADGE}
         />
       )}
+      <ExportFlowModal
+        flowDoc={currentFlowDoc}
+        hidden={!isExportFlowModalShown}
+        onClose={exportModalCloseHandler}
+      />
     </div>
   );
 };

--- a/src/components/export-flow-modal/index.js
+++ b/src/components/export-flow-modal/index.js
@@ -1,0 +1,70 @@
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import PropTypes from 'prop-types';
+
+import { Button, HeadingText, JsonChart } from 'nr1';
+
+import Modal from '../modal';
+
+const ExportFlowModal = ({ flowDoc, hidden = true, onClose }) => {
+  const [data, setData] = useState(null);
+  const linkRef = useRef(null);
+
+  useEffect(() => {
+    const { created: _, ...flow } = flowDoc || {}; // eslint-disable-line no-unused-vars
+    setData(flow);
+  }, [flowDoc]);
+
+  const downloadButtonClickHandler = useCallback(() => {
+    const exportBtn = linkRef.current;
+    if (!exportBtn) return;
+
+    const jsonStr = JSON.stringify(data);
+    const blob = new Blob([JSON.stringify(jsonStr)], {
+      type: 'application/json',
+    });
+    const url = URL.createObjectURL(blob);
+    const fileName = `${(data?.name || 'flow')
+      .replace(/[^a-z0-9]/gi, '_')
+      .toLowerCase()}.json`;
+    exportBtn.download = fileName;
+    exportBtn.href = url;
+    exportBtn.click();
+    URL.revokeObjectURL(url);
+  }, [data]);
+
+  const closeHandler = () => onClose?.();
+
+  return (
+    <Modal hidden={hidden} onClose={closeHandler}>
+      <div className="export-flow-modal">
+        <div className="json-content">
+          <HeadingText
+            className="export-header"
+            type={HeadingText.TYPE.HEADING_3}
+          >
+            Export flow
+          </HeadingText>
+          <JsonChart className="json-chart" data={data} fullHeight fullWidth />
+        </div>
+        <div className="button-bar">
+          <a ref={linkRef} className="hidden-download-btn" />
+          <Button
+            disabled={!data}
+            variant={Button.VARIANT.PRIMARY}
+            onClick={downloadButtonClickHandler}
+          >
+            Download
+          </Button>
+        </div>
+      </div>
+    </Modal>
+  );
+};
+
+ExportFlowModal.propTypes = {
+  flowDoc: PropTypes.object,
+  hidden: PropTypes.bool,
+  onClose: PropTypes.func,
+};
+
+export default ExportFlowModal;

--- a/src/components/export-flow-modal/styles.scss
+++ b/src/components/export-flow-modal/styles.scss
@@ -1,0 +1,35 @@
+.export-flow-modal {
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  justify-content: center;
+
+  .json-content {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+
+    .export-header {
+      user-select: none;
+    }
+
+    .json-chart {
+      div:first-of-type {
+        background-color: #f3f4f4;
+        border-radius: 4px;
+      }
+    }
+  }
+
+  .button-bar {
+    display: flex;
+    justify-content: flex-end;
+    gap: 4px;
+
+    .hidden-download-btn {
+      display: none;
+    }
+  }
+}

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -30,3 +30,4 @@ export { default as SignalTooltip } from './signal-tooltip';
 export { default as StepDetailSidebar } from './step-detail-sidebar';
 export { default as EditInPlace } from './edit-in-place';
 export { default as Modal } from './modal';
+export { default as ExportFlowModal } from './export-flow-modal';

--- a/src/components/styles.scss
+++ b/src/components/styles.scss
@@ -30,3 +30,4 @@
 @import './step-detail-sidebar/styles.scss';
 @import './edit-in-place/styles.scss';
 @import './modal/styles.scss';
+@import './export-flow-modal/styles.scss';

--- a/src/utils/flow.js
+++ b/src/utils/flow.js
@@ -3,19 +3,6 @@ import { REFRESH_INTERVALS } from '../constants';
 export const flowDocument = (flows = [], flowId) =>
   flows.find(({ id }) => id === flowId)?.document;
 
-export const exportFlowDoc = (flows, flowId) => {
-  const { _, ...flow } = flowDocument(flows, flowId) || {}; // eslint-disable-line no-unused-vars
-  const exportBtn = document.createElement('a');
-  exportBtn.download = `${(flow?.name || 'flow')
-    .replace(/[^a-z0-9]/gi, '_')
-    .toLowerCase()}.json`;
-  exportBtn.href = URL.createObjectURL(
-    new Blob([JSON.stringify(flow)], { type: 'application/json' })
-  );
-  exportBtn.click();
-  exportBtn.remove();
-};
-
 export const validRefreshInterval = (interval) =>
   interval && REFRESH_INTERVALS.some(({ value }) => interval === value)
     ? interval


### PR DESCRIPTION
Closes #492 

- add an `ExportFlowModal` component to display flow json as a backup for users unable to download the flow