### PR TITLE
fix: multiple workload issues in sidebar

### DIFF
--- a/src/components/signal-detail-sidebar/incidents.js
+++ b/src/components/signal-detail-sidebar/incidents.js
@@ -1,7 +1,15 @@
 import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 
-import { Button, Card, CardBody, HeadingText, Link, SectionMessage } from 'nr1';
+import {
+  Button,
+  Card,
+  CardBody,
+  HeadingText,
+  Link,
+  SectionMessage,
+  Spinner,
+} from 'nr1';
 
 import {
   durationStringForViolation,
@@ -11,7 +19,7 @@ import {
 } from '../../utils';
 import { SIGNAL_TYPES, UI_CONTENT } from '../../constants';
 
-const Incidents = ({ type, data, timeWindow }) => {
+const Incidents = ({ type, data, timeWindow, isLoading }) => {
   const [bannerMessage, setBannerMessage] = useState('');
   const [incidentsList, setIncidentsList] = useState([]);
   const [maxIncidentsShown, setMaxIncidentsShown] = useState(1);
@@ -44,83 +52,90 @@ const Incidents = ({ type, data, timeWindow }) => {
       >
         Open Incidents
       </HeadingText>
-      <div className="alert-incidents">
-        {bannerMessage && <SectionMessage description={bannerMessage} />}
-        {data?.type === 'SERVICE_LEVEL' &&
-        data?.alertSeverity !== 'NOT_ALERTING' &&
-        !incidentsList?.length ? (
-          <SectionMessage
-            type={SectionMessage.TYPE.WARNING}
-            description={UI_CONTENT.SIGNAL.DETAILS.ALERTING_SL_NO_INCIDENT}
-          />
-        ) : null}
-        {incidentsList.reduce(
-          (
-            acc,
-            { id, name, curStatus, state, classname, opened, closed, link },
-            i
-          ) =>
-            i < maxIncidentsShown
-              ? [
-                  ...acc,
-                  <div key={id} className="alert-incident">
-                    <Card>
-                      <CardBody className="incident-card-body">
-                        <div className="incident-header">
-                          <div className={`square ${classname}`}></div>
-                          <div className={`signal-status ${classname}`}>
-                            <span>
-                              <span className="priority">{curStatus}</span>
-                              {' Issue '}
-                              <span className="event">{state}</span>
-                            </span>
-                          </div>
-                        </div>
-                        <HeadingText type={HeadingText.TYPE.HEADING_5}>
-                          {name}
-                        </HeadingText>
-                        <div className="incident-links">
-                          <Link
-                            className="detail-link"
-                            to={link}
-                            onClick={(e) =>
-                              e.target.setAttribute('target', '_blank')
-                            }
-                          >
-                            View issue
-                          </Link>
-                        </div>
-                        <div>Started: {formatTimestamp(opened)}</div>
-                        <div>
-                          Duration: {durationStringForViolation(closed, opened)}
-                        </div>
-                        {closed ? (
-                          <div>Closed: {formatTimestamp(closed)}</div>
-                        ) : null}
-                      </CardBody>
-                    </Card>
-                  </div>,
-                ]
-              : acc,
-          []
-        )}
-      </div>
-      {type === !shouldShowAllIncidents && incidentsList?.length > 1 ? (
-        <div className="incidents-footer">
-          <Button
-            variant={Button.VARIANT.SECONDARY}
-            onClick={() => {
-              setMaxIncidentsShown((mis) =>
-                mis === 1 ? incidentsList.length : 1
-              );
-            }}
-          >
-            {maxIncidentsShown === 1
-              ? `Show ${incidentsList.length - 1} more incidents`
-              : 'Show less incidents'}
-          </Button>
-        </div>
-      ) : null}
+      {isLoading ? (
+        <Spinner />
+      ) : (
+        <>
+          <div className="alert-incidents">
+            {bannerMessage && <SectionMessage description={bannerMessage} />}
+            {data?.type === 'SERVICE_LEVEL' &&
+            data?.alertSeverity !== 'NOT_ALERTING' &&
+            !incidentsList?.length ? (
+              <SectionMessage
+                type={SectionMessage.TYPE.WARNING}
+                description={UI_CONTENT.SIGNAL.DETAILS.ALERTING_SL_NO_INCIDENT}
+              />
+            ) : null}
+            {incidentsList.reduce(
+              (
+                acc,
+                { id, name, curStatus, state, classname, opened, closed, link },
+                i
+              ) =>
+                i < maxIncidentsShown
+                  ? [
+                      ...acc,
+                      <div key={id} className="alert-incident">
+                        <Card>
+                          <CardBody className="incident-card-body">
+                            <div className="incident-header">
+                              <div className={`square ${classname}`}></div>
+                              <div className={`signal-status ${classname}`}>
+                                <span>
+                                  <span className="priority">{curStatus}</span>
+                                  {' Issue '}
+                                  <span className="event">{state}</span>
+                                </span>
+                              </div>
+                            </div>
+                            <HeadingText type={HeadingText.TYPE.HEADING_5}>
+                              {name}
+                            </HeadingText>
+                            <div className="incident-links">
+                              <Link
+                                className="detail-link"
+                                to={link}
+                                onClick={(e) =>
+                                  e.target.setAttribute('target', '_blank')
+                                }
+                              >
+                                View issue
+                              </Link>
+                            </div>
+                            <div>Started: {formatTimestamp(opened)}</div>
+                            <div>
+                              Duration:{' '}
+                              {durationStringForViolation(closed, opened)}
+                            </div>
+                            {closed ? (
+                              <div>Closed: {formatTimestamp(closed)}</div>
+                            ) : null}
+                          </CardBody>
+                        </Card>
+                      </div>,
+                    ]
+                  : acc,
+              []
+            )}
+          </div>
+          {type === !shouldShowAllIncidents && incidentsList?.length > 1 ? (
+            <div className="incidents-footer">
+              <Button
+                variant={Button.VARIANT.SECONDARY}
+                onClick={() => {
+                  setMaxIncidentsShown((mis) =>
+                    mis === 1 ? incidentsList.length : 1
+                  );
+                }}
+              >
+                {maxIncidentsShown === 1
+                  ? `Show ${incidentsList.length - 1} more incidents`
+                  : 'Show less incidents'}
+              </Button>
+            </div>
+          ) : null}
+        </>
+      )}
     </div>
   );
 };
@@ -129,6 +144,7 @@ Incidents.propTypes = {
   type: PropTypes.oneOf(Object.values(SIGNAL_TYPES)),
   data: PropTypes.object,
   timeWindow: PropTypes.object,
+  isLoading: PropTypes.bool,
 };
 
 export default Incidents;

--- a/src/components/signal-detail-sidebar/index.js
+++ b/src/components/signal-detail-sidebar/index.js
@@ -1,4 +1,4 @@
-import React, { useContext, useEffect, useRef, useState } from 'react';
+import React, { useContext, useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 
 import {
@@ -12,15 +12,17 @@ import {
   navigation,
 } from 'nr1';
 
-import { SIGNAL_TYPES, STATUSES } from '../../constants';
-
 import Incidents from './incidents';
 import GoldenMetrics from './golden-metrics';
 import { AppContext } from '../../contexts';
+import {
+  workloadEntitiesQuery,
+  workloadEntitiesViolationsFromGuidsArray,
+} from '../../queries';
+import { formatTimestamp, isWorkload } from '../../utils';
+import { MAX_PARAMS_IN_QUERY, SIGNAL_TYPES, STATUSES } from '../../constants';
 
 import typesList from '../../../nerdlets/signal-selection/types.json';
-import { formatTimestamp, isWorkload } from '../../utils';
-import { statusesFromGuidsArray, workloadEntitiesQuery } from '../../queries';
 
 const NO_ENTITY_TYPE = '(unknown entity type)';
 
@@ -33,13 +35,27 @@ const entityTypeFromData = (entityData) => {
   );
 };
 
+const isWorkloadNotOK = ({ statusValueCode, alertSeverity } = {}) => {
+  const notOKStatusValueCodes = [2, 3];
+  const notOKAlertSeveritiesRE = new RegExp(
+    `${STATUSES.CRITICAL}|${STATUSES.WARNING}`,
+    'i'
+  );
+
+  return (
+    notOKStatusValueCodes.includes(statusValueCode) ||
+    notOKAlertSeveritiesRE.test(alertSeverity)
+  );
+};
+
 const SignalDetailSidebar = ({ guid, name, type, data, timeWindow }) => {
   const { account = {}, accounts = [] } = useContext(AppContext);
   const [hasAccessToEntity, setHasAccessToEntity] = useState(false);
   const [signalAccount, setSignalAccount] = useState();
   const [detailLinkText, setDetailLinkText] = useState('View entity details');
   const [incidentsData, setIncidentsData] = useState(null);
-  const prevTimeWindow = useRef({});
+  const [isLoadingWorkloadViolations, setIsLoadingWorkloadViolations] =
+    useState(false);
 
   useEffect(() => {
     const [acctId, condId] = ((atob(guid) || '').split('|') || []).reduce(
@@ -64,27 +80,19 @@ const SignalDetailSidebar = ({ guid, name, type, data, timeWindow }) => {
   }, [guid, type, account, accounts]);
 
   useEffect(() => {
+    if (!guid || !type) return;
+    let curData = { ...data };
     if (
+      !data ||
       type !== SIGNAL_TYPES.ENTITY ||
       !isWorkload(data) ||
-      !(
-        data.statusValueCode === 3 ||
-        data.statusValueCode === 2 ||
-        data.alertSeverity === STATUSES.CRITICAL ||
-        data.alertSeverity === STATUSES.WARNING
-      )
+      !isWorkloadNotOK(data)
     ) {
       setIncidentsData(data);
       return;
     }
 
-    let shouldClearData = false;
-    const { start: prevStart, end: prevEnd } = prevTimeWindow.current || {};
-    if (timeWindow.start !== prevStart || timeWindow.end !== prevEnd) {
-      shouldClearData = true;
-      prevTimeWindow.current = timeWindow;
-    }
-
+    setIsLoadingWorkloadViolations(true);
     const loadWorkloadIncidents = async (g) => {
       const {
         data: {
@@ -101,15 +109,27 @@ const SignalDetailSidebar = ({ guid, name, type, data, timeWindow }) => {
         console.error('Error listing workload entities', error);
         return;
       }
-      const workloadEntitiesGuids = results?.reduce(
-        (acc, { target: { guid: g } = {} }) => (g ? [...acc, g] : acc),
-        []
-      );
+      let workloadEntitiesGuids = [];
+      for (let i = 0; i < results?.length; i += MAX_PARAMS_IN_QUERY) {
+        const guidsArr = results
+          .slice(i, i + MAX_PARAMS_IN_QUERY)
+          .map(({ target: { guid: g } = {} }) => g)
+          .filter((g) => !!g);
+        workloadEntitiesGuids = [...workloadEntitiesGuids, guidsArr];
+      }
+      if (!workloadEntitiesGuids.length) {
+        console.error('Unable to fetch workload entities');
+        setIsLoadingWorkloadViolations(false);
+        return;
+      }
       const {
         data: { actor: { __typename, ...entitiesObj } = {} } = {}, // eslint-disable-line no-unused-vars
         error: error2,
       } = await NerdGraphQuery.query({
-        query: statusesFromGuidsArray([workloadEntitiesGuids], timeWindow),
+        query: workloadEntitiesViolationsFromGuidsArray(
+          workloadEntitiesGuids,
+          timeWindow
+        ),
       });
       if (error2) {
         console.error('Error loading workload entities', error2);
@@ -127,26 +147,18 @@ const SignalDetailSidebar = ({ guid, name, type, data, timeWindow }) => {
           }
           const violations = entity?.[violationsKey] || [];
           if (violations.length) {
-            setIncidentsData((d) =>
-              d && !shouldClearData
-                ? {
-                    ...d,
-                    [violationsKey]: [
-                      ...(d[violationsKey] || []),
-                      ...violations,
-                    ],
-                  }
-                : {
-                    ...data,
-                    [violationsKey]: [
-                      ...(data[violationsKey] || []),
-                      ...violations,
-                    ],
-                  }
-            );
+            curData = {
+              ...curData,
+              [violationsKey]: [
+                ...(curData[violationsKey] || []),
+                ...violations,
+              ],
+            };
           }
         });
       });
+      setIncidentsData(curData);
+      setIsLoadingWorkloadViolations(false);
     };
     loadWorkloadIncidents(guid);
   }, [guid, type, data, timeWindow]);
@@ -190,7 +202,12 @@ const SignalDetailSidebar = ({ guid, name, type, data, timeWindow }) => {
       </div>
       {hasAccessToEntity ? (
         <>
-          <Incidents type={type} data={incidentsData} timeWindow={timeWindow} />
+          <Incidents
+            type={type}
+            data={incidentsData}
+            timeWindow={timeWindow}
+            isLoading={isLoadingWorkloadViolations}
+          />
           {type === SIGNAL_TYPES.ENTITY ? (
             <GoldenMetrics guid={guid} data={data} timeWindow={timeWindow} />
           ) : null}

--- a/src/queries/entities.js
+++ b/src/queries/entities.js
@@ -172,6 +172,45 @@ const workloadEntitiesQuery = ngql`query ($guid: EntityGuid!) {
   }
 }`;
 
+const workloadEntitiesViolationsFromGuidsArray = (
+  arrayOfGuids = [],
+  timeWindow
+) => `{
+  actor {
+    ${arrayOfGuids.map(
+      (arr, idx) => `
+      e${idx}: entities(
+        guids: ["${arr.join('", "')}"]
+      ) {
+        ${
+          timeWindow?.start && timeWindow?.end
+            ? `alertViolations(startTime: ${timeWindow.start}, endTime: ${timeWindow.end}) {
+                alertSeverity
+                closedAt
+                label
+                openedAt
+                violationId
+                violationUrl
+              }`
+            : `alertSeverity
+              recentAlertViolations {
+                alertSeverity
+                closedAt
+                label
+                openedAt
+                violationId
+                violationUrl
+              }`
+        }
+        domain
+        guid
+        type
+      }
+    `
+    )}
+  }
+}`;
+
 export {
   entitiesByDomainTypeAccountQuery,
   entityCountByAccountQuery,
@@ -181,4 +220,5 @@ export {
   statusFromGuid,
   workloadsStatusesQuery,
   workloadEntitiesQuery,
+  workloadEntitiesViolationsFromGuidsArray,
 };


### PR DESCRIPTION
Closes #502 

- fixes issues from #504 
  - violations not  showing when not in playback mode
  - violations were on props change in certain situations
- adding a loading indicator when violations from workload entities are being fetched in the sidebar
- refactor query that fetches violations for workloads entities to fetch only required data 