### PR TITLE
fix: step panel enhancements

### DIFF
--- a/src/components/step-detail-sidebar/index.js
+++ b/src/components/step-detail-sidebar/index.js
@@ -1,7 +1,7 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import PropTypes from 'prop-types';
 
-import { Card, CardBody, HeadingText, Link } from 'nr1';
+import { Card, CardBody, HeadingText, Icon, Link } from 'nr1';
 
 import IconsLib from '../icons-lib';
 import {
@@ -72,10 +72,7 @@ const StepDetailSidebar = ({ step: { title, link, signals, ...step } }) => {
             <HeadingText type={HeadingText.TYPE.HEADING_6}>
               STEP DETAILS
             </HeadingText>
-            <HeadingText type={HeadingText.TYPE.HEADING_3}>
-              {title}
-              {step.excluded ? '*' : ''}
-            </HeadingText>
+            <HeadingText type={HeadingText.TYPE.HEADING_3}>{title}</HeadingText>
             {link ? (
               <Link
                 className="detail-link"
@@ -92,6 +89,16 @@ const StepDetailSidebar = ({ step: { title, link, signals, ...step } }) => {
         <HeadingText type={HeadingText.TYPE.HEADING_5}>
           {UI_CONTENT.STEP.PANEL.CONFIG_TITLE}
         </HeadingText>
+        {step.excluded ? (
+          <div className="step-excluded">
+            <Icon color="#f07a0e" type={Icon.TYPE.INTERFACE__STATE__WARNING} />
+            <span className="excluded-message">
+              {UI_CONTENT.STEP.PANEL.EXCLUDE_MESSAGE}
+            </span>
+          </div>
+        ) : (
+          ''
+        )}
         <div className="status-calculation">{signalsStatusRule}</div>
         <div className="included-signals-list">
           {includedSignals.map(({ guid, name, status, type }) => (
@@ -108,10 +115,6 @@ const StepDetailSidebar = ({ step: { title, link, signals, ...step } }) => {
               <span title={name}>{name}</span>
             </div>
           ))}
-        </div>
-        <br />
-        <div className="step-excluded">
-          {step.excluded ? UI_CONTENT.STEP.PANEL.EXCLUDE_MESSAGE : ''}
         </div>
       </div>
     </div>

--- a/src/components/step-detail-sidebar/index.js
+++ b/src/components/step-detail-sidebar/index.js
@@ -50,7 +50,7 @@ const StepDetailSidebar = ({ step: { title, link, signals, ...step } }) => {
           <span className="status-option">{statusOption}</span>
           <span>
             status -{` ${weightAppliedMessage}${includedSignals.length} `}
-            signals
+            selected signals:
           </span>
         </>
       );
@@ -59,7 +59,7 @@ const StepDetailSidebar = ({ step: { title, link, signals, ...step } }) => {
     return (
       <>
         <span className="status-option">{statusOption}</span>
-        <span> status of {includedSignals.length} signals</span>
+        <span> status of {includedSignals.length} selected signals:</span>
       </>
     );
   }, [includedSignals, step]);
@@ -72,7 +72,10 @@ const StepDetailSidebar = ({ step: { title, link, signals, ...step } }) => {
             <HeadingText type={HeadingText.TYPE.HEADING_6}>
               STEP DETAILS
             </HeadingText>
-            <HeadingText type={HeadingText.TYPE.HEADING_3}>{title}</HeadingText>
+            <HeadingText type={HeadingText.TYPE.HEADING_3}>
+              {title}
+              {step.excluded ? '*' : ''}
+            </HeadingText>
             {link ? (
               <Link
                 className="detail-link"
@@ -86,6 +89,9 @@ const StepDetailSidebar = ({ step: { title, link, signals, ...step } }) => {
         </Card>
       </div>
       <div className="signals-status-rule">
+        <HeadingText type={HeadingText.TYPE.HEADING_5}>
+          {UI_CONTENT.STEP.PANEL.CONFIG_TITLE}
+        </HeadingText>
         <div className="status-calculation">{signalsStatusRule}</div>
         <div className="included-signals-list">
           {includedSignals.map(({ guid, name, status, type }) => (
@@ -102,6 +108,10 @@ const StepDetailSidebar = ({ step: { title, link, signals, ...step } }) => {
               <span title={name}>{name}</span>
             </div>
           ))}
+        </div>
+        <br />
+        <div className="step-excluded">
+          {step.excluded ? UI_CONTENT.STEP.PANEL.EXCLUDE_MESSAGE : ''}
         </div>
       </div>
     </div>

--- a/src/components/step-detail-sidebar/styles.scss
+++ b/src/components/step-detail-sidebar/styles.scss
@@ -21,6 +21,14 @@
     display: flex;
     flex-direction: column;
     gap: 8px;
+
+    .step-excluded {
+      font-weight: 200;
+
+      .excluded-message {
+        margin-left: 4px;
+      }
+    }
     
     .status-calculation {
       display: inline-flex;

--- a/src/components/step-detail-sidebar/styles.scss
+++ b/src/components/step-detail-sidebar/styles.scss
@@ -39,6 +39,7 @@
       display: flex;
       flex-direction: column;
       gap: 4px;
+      text-indent: 12px;
 
       .included-signal {
         box-sizing: border-box;
@@ -47,6 +48,8 @@
         align-items: center;
         gap: 8px;
         margin-bottom: 2px;
+        white-space: nowrap;
+        overflow: ellipsis;
 
         .icons-lib {
           @include fill-colors(

--- a/src/constants/ui-content.js
+++ b/src/constants/ui-content.js
@@ -82,6 +82,10 @@ export const UI_CONTENT = {
   },
   STEP: {
     DEFAULT_TITLE: 'Untitled step',
+    PANEL: {
+      CONFIG_TITLE: 'Step Configuration',
+      EXCLUDE_MESSAGE: '*step excluded from level health',
+    },
     NO_SIGNALS: {
       TITLE: 'No signals yet',
       DESCRIPTION:

--- a/src/constants/ui-content.js
+++ b/src/constants/ui-content.js
@@ -84,7 +84,7 @@ export const UI_CONTENT = {
     DEFAULT_TITLE: 'Untitled step',
     PANEL: {
       CONFIG_TITLE: 'Step Configuration',
-      EXCLUDE_MESSAGE: '*step excluded from level health',
+      EXCLUDE_MESSAGE: 'Excluded from level health',
     },
     NO_SIGNALS: {
       TITLE: 'No signals yet',


### PR DESCRIPTION
- added header `Step Configuration` above status rule text
- added word `selected` to status text
- indented signals to show they are under config section
- Added indicator if step is excluded from level health status/rollup